### PR TITLE
ublksrv: add NEED_GET_DATA support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.common
 
 TOP_DIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
-override CFLAGS += -I include
+override CFLAGS += -I include -DNEED_GET_DATA
 
 UBLKSRV_OBJS = utils.o ublksrv_tgt.o tgt_null.o tgt_loop.o
 UBLKSRV_PROG = ublk

--- a/demo_event.c
+++ b/demo_event.c
@@ -315,6 +315,11 @@ int main(int argc, char *argv[])
 	if (signal(SIGINT, sig_handler) == SIG_ERR)
 		return -1;
 
+#ifdef NEED_GET_DATA
+	fprintf(stdout, "%s: UBLK_F_NEED_GET_DATA\n", __func__);		
+	data.flags[0] = UBLK_F_NEED_GET_DATA;
+#endif
+
 	data.ublksrv_flags = UBLKSRV_F_NEED_EVENTFD;
 	dev = ublksrv_ctrl_init(&data);
 	if (!dev) {

--- a/demo_null.c
+++ b/demo_null.c
@@ -183,6 +183,10 @@ int main(int argc, char *argv[])
 			break;
 		}
 	}
+#ifdef NEED_GET_DATA
+	fprintf(stdout, "%s: UBLK_F_NEED_GET_DATA\n", __func__);		
+	data.flags[0] = UBLK_F_NEED_GET_DATA;
+#endif
 
 	if (signal(SIGTERM, sig_handler) == SIG_ERR)
 		return -1;

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -109,7 +109,7 @@ struct ublk_io {
 #define UBLKSRV_NEED_FETCH_RQ		(1UL << 0)
 #define UBLKSRV_NEED_COMMIT_RQ_COMP	(1UL << 1)
 #define UBLKSRV_IO_FREE			(1UL << 2)
-#define UBLKSRV_NEED_REFETCH_RQ		(1UL << 3)
+#define UBLKSRV_NEED_GET_DATA		(1UL << 3)
 	unsigned int flags;
 
 	union {

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -160,12 +160,12 @@ static inline int ublksrv_queue_io_cmd(struct ublksrv_queue *q,
 
 	/* we issue because we need either fetching or committing */
 	if (!(io->flags &
-		(UBLKSRV_NEED_FETCH_RQ | UBLKSRV_NEED_REFETCH_RQ |
+		(UBLKSRV_NEED_FETCH_RQ | UBLKSRV_NEED_GET_DATA |
 		 UBLKSRV_NEED_COMMIT_RQ_COMP)))
 		return 0;
 
-	if (io->flags & UBLKSRV_NEED_REFETCH_RQ)
-		cmd_op = UBLK_IO_REFETCH_REQ;
+	if (io->flags & UBLKSRV_NEED_GET_DATA)
+		cmd_op = UBLK_IO_NEED_GET_DATA;
 	else if (io->flags & UBLKSRV_NEED_COMMIT_RQ_COMP)
 		cmd_op = UBLK_IO_COMMIT_AND_FETCH_REQ;
 	else if (io->flags & UBLKSRV_NEED_FETCH_RQ)
@@ -758,8 +758,8 @@ static void ublksrv_handle_cqe(struct io_uring *r,
 	 */
 	if (cqe->res == UBLK_IO_RES_OK) {
 		tgt->ops->handle_io_async(q, tag);
-	} else if (cqe->res == UBLK_IO_RES_REFETCH) {
-		io->flags |= UBLKSRV_NEED_REFETCH_RQ | UBLKSRV_IO_FREE;
+	} else if (cqe->res == UBLK_IO_RES_NEED_GET_DATA) {
+		io->flags |= UBLKSRV_NEED_GET_DATA | UBLKSRV_IO_FREE;
 		ublksrv_queue_io_cmd(q, io, tag);
 	} else {
 		/*


### PR DESCRIPTION
This commit add a new ublk command: UBLK_IO_NEED_GET_DATA
and corresponding IO result and flag.

For a write request, ublk_drv should return UBLK_IO_RES_NEED_GET_DATA.
Now a user application has a chance to allocate and set IO buffer
address after receiving one IO request from ublk kernel driver.
Then, ubksrv issue a new ublk IO command with UBLK_IO_NEED_GET_DATA.
Finally, the ublk kernel driver should copy bio vector data to be
written to this user provided buffer.

Also add UBLK_F_NEED_GET_DATA flag in demo_null and demo_event to
test performance of the new feature. Now just control this flag by a
macro defined in Makefile for test usage.

This commit should be tested with the new kernel patch:
https://lore.kernel.org/all/9993fb25-ecd1-4682-99b9-e83472583897@linux.alibaba.com/

Signed-off-by: ZiyangZhang <ZiyangZhang@linux.alibaba.com>