### PR TITLE
[v2]ublksrv: add NEED_GET_DATA support 

### DIFF
--- a/demo_event.c
+++ b/demo_event.c
@@ -332,8 +332,13 @@ int main(int argc, char *argv[])
 	if (signal(SIGINT, sig_handler) == SIG_ERR)
 		return -1;
 
-	pthread_mutex_init(&jbuf_lock, NULL);
+	if (argc == 2 && strcmp("need_get_data", argv[1]) == 0) {
+		fprintf(stdout, "%s: UBLK_F_NEED_GET_DATA\n", __func__);		
+		data.flags = UBLK_F_NEED_GET_DATA;
+	}
 
+	pthread_mutex_init(&jbuf_lock, NULL);
+	
 	data.ublksrv_flags = UBLKSRV_F_NEED_EVENTFD;
 	dev = ublksrv_ctrl_init(&data);
 	if (!dev) {

--- a/demo_null.c
+++ b/demo_null.c
@@ -200,6 +200,10 @@ int main(int argc, char *argv[])
 			break;
 		}
 	}
+	if (argc == 2 && strcmp("need_get_data", argv[1]) == 0) {
+		fprintf(stdout, "%s: UBLK_F_NEED_GET_DATA\n", __func__);		
+		data.flags = UBLK_F_NEED_GET_DATA;
+	}
 
 	if (signal(SIGTERM, sig_handler) == SIG_ERR)
 		return -1;

--- a/include/ublk_cmd.h
+++ b/include/ublk_cmd.h
@@ -29,18 +29,20 @@
  *      driver, meantime FETCH_REQ is piggyback, and FETCH_REQ has to be
  *      handled before completing io request.
  *
- * REFETCH_REQ: issued via sqe(URING_CMD) after ublk driver returns
- * 	UBLK_IO_REFETCH_REQ, which only purpose is to fetch io request data
- * 	from the userspace ublk server context in case that task_work_add
- * 	isn't available because ublk driver is built as module
+ * NEED_GET_DATA: only used for write requests to set io addr and copy data
+ *      When NEED_GET_DATA is set, ublksrv has to issue UBLK_IO_NEED_GET_DATA
+ *      command after ublk driver returns UBLK_IO_RES_NEED_GET_DATA.
+ *
+ *      It is only used if ublksrv set UBLK_F_NEED_GET_DATA flag
+ *      while starting a ublk device.
  */
 #define	UBLK_IO_FETCH_REQ		0x20
 #define	UBLK_IO_COMMIT_AND_FETCH_REQ	0x21
-#define	UBLK_IO_REFETCH_REQ		0x22
+#define UBLK_IO_NEED_GET_DATA	0x22
 
 /* only ABORT means that no re-fetch */
 #define UBLK_IO_RES_OK			0
-#define UBLK_IO_RES_REFETCH		1
+#define UBLK_IO_RES_NEED_GET_DATA	1
 #define UBLK_IO_RES_ABORT		(-ENODEV)
 
 #define UBLKSRV_CMD_BUF_OFFSET	0
@@ -60,6 +62,15 @@
  * performance comparison is done easily with using task_work_add
  */
 #define UBLK_F_URING_CMD_COMP_IN_TASK	(1ULL << 1)
+
+/*
+ * User should issue io cmd again for write requests to
+ * set io buffer address and copy data from bio vectors
+ * to the userspace io buffer.
+ *
+ * In this mode, task_work is not used.
+ */
+#define UBLK_F_NEED_GET_DATA (1UL << 2)
 
 /* device state */
 #define UBLK_S_DEV_DEAD	0

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -117,7 +117,7 @@ struct ublk_io {
 #define UBLKSRV_NEED_FETCH_RQ		(1UL << 0)
 #define UBLKSRV_NEED_COMMIT_RQ_COMP	(1UL << 1)
 #define UBLKSRV_IO_FREE			(1UL << 2)
-#define UBLKSRV_NEED_REFETCH_RQ		(1UL << 3)
+#define UBLKSRV_NEED_GET_DATA		(1UL << 3)
 	unsigned int flags;
 
 	union {

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -160,12 +160,12 @@ static inline int ublksrv_queue_io_cmd(struct ublksrv_queue *q,
 
 	/* we issue because we need either fetching or committing */
 	if (!(io->flags &
-		(UBLKSRV_NEED_FETCH_RQ | UBLKSRV_NEED_REFETCH_RQ |
+		(UBLKSRV_NEED_FETCH_RQ | UBLKSRV_NEED_GET_DATA |
 		 UBLKSRV_NEED_COMMIT_RQ_COMP)))
 		return 0;
 
-	if (io->flags & UBLKSRV_NEED_REFETCH_RQ)
-		cmd_op = UBLK_IO_REFETCH_REQ;
+	if (io->flags & UBLKSRV_NEED_GET_DATA)
+		cmd_op = UBLK_IO_NEED_GET_DATA;
 	else if (io->flags & UBLKSRV_NEED_COMMIT_RQ_COMP)
 		cmd_op = UBLK_IO_COMMIT_AND_FETCH_REQ;
 	else if (io->flags & UBLKSRV_NEED_FETCH_RQ)
@@ -755,8 +755,8 @@ static void ublksrv_handle_cqe(struct io_uring *r,
 	 */
 	if (cqe->res == UBLK_IO_RES_OK) {
 		tgt->ops->handle_io_async(q, tag);
-	} else if (cqe->res == UBLK_IO_RES_REFETCH) {
-		io->flags |= UBLKSRV_NEED_REFETCH_RQ | UBLKSRV_IO_FREE;
+	} else if (cqe->res == UBLK_IO_RES_NEED_GET_DATA) {
+		io->flags |= UBLKSRV_NEED_GET_DATA | UBLKSRV_IO_FREE;
 		ublksrv_queue_io_cmd(q, io, tag);
 	} else {
 		/*

--- a/tests/common/fio_common
+++ b/tests/common/fio_common
@@ -207,6 +207,7 @@ __create_ublk_dev()
 	ublk_type=$1
 	nr_queues=$2
 	uring_comp=$3
+	need_get_data=$4
 
 	[ "$nr_queues" = "" ] && nr_queues=1
 
@@ -215,7 +216,7 @@ __create_ublk_dev()
 		truncate -s 2G $file
 	fi
 
-	eval $UBLK add -t $ublk_type -q $nr_queues -u $uring_comp -d 128 -f $file > /dev/null 2>&1
+	eval $UBLK add -t $ublk_type -q $nr_queues -u $uring_comp -g $need_get_data -d 128 -f $file > /dev/null 2>&1
 }
 
 __remove_kernel_loop_dev() {
@@ -272,11 +273,11 @@ __run_dev_perf()
 	DEV="/dev/ublkb0"
 
 	__remove_ublk_dev
-	__create_ublk_dev $TYPE $QUEUES $T_URING_COMP
+	__create_ublk_dev $TYPE $QUEUES $T_URING_COMP $T_NEED_GET_DATA
 
 	FILE=`__ublk_loop_backing_file`
 
-	echo -e "\tfio (ublk/$TYPE($FILE), libaio, bs 4k, dio, hw queues:$QUEUES, uring_comp: $T_URING_COMP)..."
+	echo -e "\tfio (ublk/$TYPE($FILE), libaio, bs 4k, dio, hw queues:$QUEUES, uring_comp: $T_URING_COMP, need_get_data: $T_NEED_GET_DATA)..."
 	__run_dev_perf_no_create $TYPE $JOBS $QUEUES $DEV $FILE
 
 	__remove_ublk_dev 0

--- a/tests/generic/001
+++ b/tests/generic/001
@@ -12,10 +12,11 @@ QUEUES=4
 RT=$TRUNTIME
 LOOPS=4
 URING_COMP=1
+NEED_GET_DATA=1
 
 for CNT in `seq $LOOPS`; do
-	__create_ublk_dev "loop" $QUEUES $URING_COMP
-	echo -e "\trun fio on ublk(uring_comp $URING_COMP) with delete $CNT"
+	__create_ublk_dev "loop" $QUEUES $URING_COMP $NEED_GET_DATA
+	echo -e "\trun fio on ublk(uring_comp $URING_COMP, need_get_data $NEED_GET_DATA) with delete $CNT"
 	__run_fio_libaio "/dev/ublkb0" $BS $RW $JOBS $RT > /dev/null 2 >& 1 &
 	sleep 4
 	RES=`__remove_ublk_dev_return 0`

--- a/tests/generic/002
+++ b/tests/generic/002
@@ -12,10 +12,11 @@ QUEUES=2
 RT=$TRUNTIME
 LOOPS=4
 URING_COMP=1
+NEED_GET_DATA=1
 
 for CNT in `seq $LOOPS`; do
-	__create_ublk_dev "null" $QUEUES $URING_COMP
-	echo -e "\trun fio with killing ublk(uring_comp $URING_COMP) queue daemon $CNT"
+	__create_ublk_dev "null" $QUEUES $URING_COMP $NEED_GET_DATA
+	echo -e "\trun fio with killing ublk(uring_comp $URING_COMP, need_get_data $NEED_GET_DATA) queue daemon $CNT"
 	__run_fio_libaio "/dev/ublkb0" $BS $RW $JOBS $RT > /dev/null 2 >& 1 &
 	sleep 2
 	queue_tid=`__ublk_get_queue_tid 0`

--- a/tests/generic/003
+++ b/tests/generic/003
@@ -4,8 +4,8 @@
 
 ublk_run_mount_test()
 {
-	echo -n -e "\tmount/umount ublk device with root fstype(pin page $1, uring_comp: $2)..."
-	__create_ublk_dev "loop" $QUEUES $1
+	echo -n -e "\tmount/umount ublk device with root fstype(uring_comp: $1, need_get_data: $2)..."
+	__create_ublk_dev "loop" $QUEUES $1 $2
 
 	ROOT_FSTYPE=`findmnt -l -o FSTYPE -n /`
 
@@ -29,7 +29,8 @@ DEV=/dev/ublkb0
 QUEUES=2
 MNT=`mktemp -d`
 URING_COMP=1
+NEED_GET_DATA=1
 
-ublk_run_mount_test $URING_COMP
+ublk_run_mount_test $URING_COMP $NEED_GET_DATA
 
 rm -fr $MNT

--- a/tests/loop/006
+++ b/tests/loop/006
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. common/fio_common
+
+export T_NEED_GET_DATA=1
+__run_dev_perf "loop" 1 1

--- a/tests/loop/007
+++ b/tests/loop/007
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. common/fio_common
+
+export T_URING_COMP=1
+export T_NEED_GET_DATA=1
+__run_dev_perf "loop" 1 1

--- a/tests/null/006
+++ b/tests/null/006
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. common/fio_common
+
+export T_NEED_GET_DATA=1
+
+__run_dev_perf "null" 1 1

--- a/tests/null/007
+++ b/tests/null/007
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. common/fio_common
+
+export T_URING_COMP=1
+export T_NEED_GET_DATA=1
+
+__run_dev_perf "null" 1 1

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -26,6 +26,7 @@ run_test() {
 TEST=$1
 export TRUNTIME=$2
 export T_URING_COMP=0
+export T_NEED_GET_DATA=0
 
 if [ -d $TEST ]; then
 		for ITEM in `ls ${TEST} | grep -v "~$"`; do

--- a/ublksrv_tgt.c
+++ b/ublksrv_tgt.c
@@ -466,6 +466,7 @@ static int cmd_dev_add(int argc, char *argv[])
 	int opt, ret, zcopy = 0;
 	int daemon_pid;
 	int uring_comp = 0;
+	int need_get_data = 0;
 	const char *dump_buf;
 
 	data.queue_depth = DEF_QD;
@@ -477,7 +478,7 @@ static int cmd_dev_add(int argc, char *argv[])
 
 	mkpath(data.run_dir);
 
-	while ((opt = getopt_long(argc, argv, "-:t:n:d:q:u:z",
+	while ((opt = getopt_long(argc, argv, "-:t:n:d:q:u:g:z",
 				  longopts, NULL)) != -1) {
 		switch (opt) {
 		case 'n':
@@ -499,6 +500,9 @@ static int cmd_dev_add(int argc, char *argv[])
 		case 'u':
 			uring_comp = strtol(optarg, NULL, 10);
 			break;
+		case 'g':
+			need_get_data = strtol(optarg, NULL, 10);
+			break;
 		}
 	}
 	data.rq_max_blocks = DEF_BUF_SIZE / data.block_size;
@@ -508,6 +512,8 @@ static int cmd_dev_add(int argc, char *argv[])
 		data.queue_depth = MAX_QD;
 	if (uring_comp)
 		data.flags |= UBLK_F_URING_CMD_COMP_IN_TASK;
+	if (need_get_data)
+		data.flags |= UBLK_F_NEED_GET_DATA;
 
 	//optind = 0;	/* so that tgt code can parse their arguments */
 	data.tgt_argc = argc;
@@ -588,7 +594,8 @@ static void cmd_dev_add_usage(char *cmd)
 	ublksrv_for_each_tgt_type(collect_tgt_types, &data);
 	data.pos += snprintf(data.names + data.pos, 4096 - data.pos, "}");
 
-	printf("%s add -t %s -n DEV_ID -q NR_HW_QUEUES -d QUEUE_DEPTH -u URING_COMP\n",
+	printf("%s add -t %s -n DEV_ID -q NR_HW_QUEUES -d QUEUE_DEPTH "
+			"-u URING_COMP -g NEED_GET_DATA\n",
 			cmd, data.names);
 	ublksrv_for_each_tgt_type(show_tgt_add_usage, NULL);
 }


### PR DESCRIPTION
UBLKSRV_NEED_GET_DATA is one new flag used by ublksrv to support
NEED_GET_DATA in ublk.

For now, ublk only support pre-allocated buffer which stores data
to be written/read by backend(target). In this way, a backend has
no chance to pass its own data buffer(e,g. RPC buffer) to ublksrv AFTER
it gets a write request and one additional copy (from ublksrv
pre-allocated buffer to backend's buffer) is necessary.

NEED_GET_DATA is one new feature for users who want to set IO buffer
ONLY AFTER it gets one new WRITE request.

In detail, NEED_GET_DATA works as follow:

(1) After ublksrv get UBLK_IO_RES_NEED_GET_DATA from a cqe. It should
   set UBLKSRV_NEED_GET_DATA. Now ublksrv does not let backend(target)
   handle this IO(write) request. At the same time, the user application
   has a chance to pass IO buffer address allocated by itself. This IO
   buffer is used to copy data from bio vectors for a WRITE request.

(2) While queuing new ublk IO command, ublksrv should check this flag
    and set opcode to UBLK_IO_NEED_GET_DATA. The new ublk IO command
    will be issued to kernel ublk_drv with new IO buffer address from
    backend.

UBLK_F_NEED_GET_DATA is one optional feature for applications.
You may choose open it or not in demo_null, demo_event and ublksrv_tgt.

Finally, test cases are added for NEED_GET_DATA and all tests passes.

changes from V1 to V2:

(1)  UBLK_F_NEED_GET_DATA as one optional feature. Users can switch it on.
(2)  Add more test cases under tests/

Signed-off-by: ZiyangZhang <ZiyangZhang@linux.alibaba.com>