### PR TITLE
Makefile: compile c++ files in lib/ with c++11

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,8 +15,8 @@ all: $(UBLKSRV_LIB) $(UBLKSRV_LIB_STATIC)
 %.o : %.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
-%.o : %.cpp Makefile
-	$(CPP) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
+ublksrv_json.o : ublksrv_json.cpp Makefile
+	$(CPP) -c $(CFLAGS) -std=c++11 $< -o $@
 
 $(UBLKSRV_LIB): $(UBLKSRV_LIB_OBJS)
 	$(CC) -shared -o $@  $(UBLKSRV_LIB_OBJS) $(LDFLAGS)


### PR DESCRIPTION
Building libublksrv(/lib) requires only one c++ file:
ublksrv_json.cpp, which depends on include/nlohmann/json.hpp.
As doc of nlohmann/json.hpp says, it only requires c++11,
so change cppflags for libublksrv from c++20 to c++11.

Signed-off-by: Ziyang Zhang <ZiyangZhang@linux.alibaba.com>