### PR TITLE
Aio

### DIFF
--- a/demo_event.c
+++ b/demo_event.c
@@ -7,25 +7,19 @@
 #include <error.h>
 
 #include "ublksrv.h"
+#include "ublksrv_aio.h"
 
 #define UBLKSRV_TGT_TYPE_DEMO  0
 
+
+static struct ublksrv_aio_ctx *aio_ctx = NULL;
+static pthread_t io_thread;
 struct demo_queue_info {
 	struct ublksrv_dev *dev;
 	struct ublksrv_queue *q;
 	int qid;
 
-	/* for notify real io handler that we have io available */
-	int efd, dead;
-
 	pthread_t thread;
-
-	pthread_t io_thread;
-
-	pthread_spinlock_t lock;
-
-	struct ublk_io *pending;
-	struct ublk_io *processed;
 };
 
 static struct ublksrv_ctrl_dev *this_ctrl_dev;
@@ -42,77 +36,47 @@ static void sig_handler(int sig)
 	ublksrv_ctrl_stop_dev(this_ctrl_dev);
 }
 
-static bool demo_add_list(struct ublk_io **head, struct ublk_io **new_list)
+static int io_submit_worker(struct ublksrv_aio_ctx *ctx,
+		struct ublksrv_aio *req)
 {
-	struct ublk_io *io, *end = NULL;
+	req->res = req->io.nr_sectors << 9;
 
-	/* add pending into ->processed list */
-	io = *head;
-	while (io) {
-		end = io;
-		io = (struct ublk_io *)io->io_data;
-	}
-
-	if (end)
-		end->io_data = (unsigned long)*new_list;
-	else
-		*head = *new_list;
-
-	io = *new_list;
-	*new_list = NULL;
-
-	return !!io;
+	return 1;
 }
 
 #define EPOLL_NR_EVENTS 1
 static void *demo_event_real_io_handler_fn(void *data)
 {
-	struct demo_queue_info *info = (struct demo_queue_info *)data;
-	struct ublksrv_dev *dev = info->dev;
-	unsigned dev_id = dev->ctrl_dev->dev_info.dev_id;
-	unsigned short q_id = info->qid;
+	struct ublksrv_aio_ctx *ctx = (struct ublksrv_aio_ctx *)data;
+
+	unsigned dev_id = ctx->dev->ctrl_dev->dev_info.dev_id;
 	struct epoll_event events[EPOLL_NR_EVENTS];
 	int epoll_fd = epoll_create(EPOLL_NR_EVENTS);
 	struct epoll_event read_event;
 	int ret;
 
 	if (epoll_fd < 0) {
-		fprintf(stderr, "ublk dev %d queue %d create epoll fd failed\n",
-				dev_id, q_id);
-		return NULL;
+	        fprintf(stderr, "ublk dev %d create epoll fd failed\n", dev_id);
+	        return NULL;
 	}
+
+	fprintf(stdout, "ublk dev %d aio context started tid %d\n", dev_id,
+			gettid());
 
 	read_event.events = EPOLLIN;
-	read_event.data.fd = info->efd;
-	ret = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, info->efd, &read_event);
-	if (ret < 0) {
-		fprintf(stderr, "ublk dev %d queue %d epoll_ctl(ADD) failed\n",
-				dev_id, q_id);
-		return NULL;
-	}
+	read_event.data.fd = ctx->efd;
+	ret = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, ctx->efd, &read_event);
 
-	/* wait until the 1st io comes */
-	//read(info->efd, &data, 8);
-	epoll_wait(epoll_fd, events, EPOLL_NR_EVENTS, -1);
+	while (!ublksrv_aio_ctx_dead(ctx)) {
+		struct aio_list compl;
 
-	while (!info->dead) {
-		int added = 0;
+		aio_list_init(&compl);
 
-		/* move all io in ->pending to ->processed */
-		pthread_spin_lock(&info->lock);
-		added = demo_add_list(&info->processed, &info->pending);
-		pthread_spin_unlock(&info->lock);
+		ublksrv_aio_submit_worker(ctx, io_submit_worker, &compl);
 
-		/*
-		 * clear internal event before sending ublksrv event which
-		 * generate new io(internal event) immediately
-		 */
-		read(info->efd, &data, 8);
+		ublksrv_aio_complete_worker(ctx, &compl);
 
-		/* tell ublksrv io_uring context that we have io done */
-		ublksrv_queue_send_event(info->q);
-
-		ret = epoll_wait(epoll_fd, events, EPOLL_NR_EVENTS, -1);
+		epoll_wait(epoll_fd, events, EPOLL_NR_EVENTS, -1);
 	}
 
 	return NULL;
@@ -154,8 +118,6 @@ static void *demo_event_io_handler_fn(void *data)
 			break;
 	} while (1);
 
-	info->dead = 1;
-	write(info->efd, &ev_data, 8);
 	fprintf(stdout, "ublk dev %d queue %d exited\n", dev_id, q->q_id);
 	ublksrv_queue_deinit(q);
 	return NULL;
@@ -206,18 +168,23 @@ static int demo_event_io_handler(struct ublksrv_ctrl_dev *ctrl_dev)
 	if (!dev)
 		return -ENOMEM;
 	this_dev = dev;
+
+
+	aio_ctx = ublksrv_aio_ctx_init(dev, 0);
+	if (!aio_ctx) {
+		fprintf(stderr, "dev %d call ublk_aio_ctx_init failed\n", dev_id);
+		return -ENOMEM;
+	}
+
+	pthread_create(&io_thread, NULL, demo_event_real_io_handler_fn,
+			aio_ctx);
 	for (i = 0; i < dinfo->nr_hw_queues; i++) {
 		int j;
-		info_array[i].efd = eventfd(0, 0);
 		info_array[i].dev = dev;
 		info_array[i].qid = i;
-		pthread_spin_init(&info_array[i].lock,
-				PTHREAD_PROCESS_PRIVATE);
+
 		pthread_create(&info_array[i].thread, NULL,
 				demo_event_io_handler_fn,
-				&info_array[i]);
-		pthread_create(&info_array[i].io_thread, NULL,
-				demo_event_real_io_handler_fn,
 				&info_array[i]);
 	}
 
@@ -235,10 +202,10 @@ static int demo_event_io_handler(struct ublksrv_ctrl_dev *ctrl_dev)
 	for (i = 0; i < dinfo->nr_hw_queues; i++) {
 		int j;
 		pthread_join(info_array[i].thread, &thread_ret);
-		pthread_join(info_array[i].io_thread, &thread_ret);
-		pthread_spin_destroy(&info_array[i].lock);
-		close(info_array[i].efd);
 	}
+	ublksrv_aio_ctx_shutdown(aio_ctx);
+	pthread_join(io_thread, &thread_ret);
+	ublksrv_aio_ctx_deinit(aio_ctx);
 
 fail:
 	ublksrv_dev_deinit(dev);
@@ -284,58 +251,20 @@ static int demo_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 
 static int demo_handle_io_async(struct ublksrv_queue *q, int tag)
 {
-	struct demo_queue_info *info = (struct demo_queue_info *)
-		ublksrv_queue_get_data(q);
-	unsigned long long data = 1;
-	struct ublk_io *io = &q->ios[tag];
-
-	/* add current io into ->pending list */
-	pthread_spin_lock(&info->lock);
-	io->io_data = (unsigned long)info->pending;
-	info->pending = io;
-	pthread_spin_unlock(&info->lock);
-
-	write(info->efd, &data, 8);
-	return 0;
-}
-
-static void demo_handle_one_io(struct ublksrv_queue *q, struct ublk_io *io)
-{
-	int tag = ((unsigned long)io - (unsigned long)&q->ios[0]) / sizeof(*io);
 	const struct ublksrv_io_desc *iod = ublksrv_get_iod(q, tag);
+	struct ublksrv_aio *req = ublksrv_aio_alloc_req(aio_ctx, 0);
 
-	ublksrv_complete_io(q, tag, iod->nr_sectors << 9);
+	req->io = *iod;
+	req->fd = -1;
+	req->id = ublksrv_aio_pid_tag(q->q_id, tag);
+	ublksrv_aio_submit_req(aio_ctx, req);
+
+	return 0;
 }
 
 static void demo_handle_event(struct ublksrv_queue *q)
 {
-	struct demo_queue_info *info = (struct demo_queue_info *)
-		ublksrv_queue_get_data(q);
-	int cnt = 0;
-
-	/* complete all ios from ->processed list */
-	while (true) {
-		struct ublk_io *io, *list;
-
-		pthread_spin_lock(&info->lock);
-		list = info->processed;
-		info->processed = NULL;
-		pthread_spin_unlock(&info->lock);
-
-		if (!list)
-			break;
-
-		io = list;
-		while (io) {
-			struct ublk_io *next = (struct ublk_io *)io->io_data;
-
-			demo_handle_one_io(info->q, io);
-			io = next;
-			cnt++;
-		}
-	}
-
-	ublksrv_queue_handled_event(info->q);
+	ublksrv_aio_handle_event(aio_ctx, q);
 }
 
 static const struct ublksrv_tgt_type demo_event_tgt_type = {

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -366,6 +366,8 @@ extern struct ublksrv_queue *ublksrv_queue_init(struct ublksrv_dev *dev,
 extern void ublksrv_queue_deinit(struct ublksrv_queue *q);
 extern int ublksrv_queue_handled_event(struct ublksrv_queue *q);
 extern int ublksrv_queue_send_event(struct ublksrv_queue *q);
+extern struct ublksrv_queue *ublksrv_get_queue(const struct ublksrv_dev *dev,
+		int q_id);
 
 extern int ublksrv_process_io(struct ublksrv_queue *q);
 extern int ublksrv_complete_io(struct ublksrv_queue *q, unsigned tag, int res);

--- a/include/ublksrv_aio.h
+++ b/include/ublksrv_aio.h
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT or LGPL-2.1-only
+#include "ublksrv.h"
+
+struct ublksrv_aio_ctx;
+struct ublksrv_aio;
+
+/*
+ * return value:
+ *
+ * > 0 : the request is done
+ * = 0 : submitted successfully, but not done
+ * < 0 : submitted not successfully
+ */
+typedef int (ublksrv_aio_submit_fn)(struct ublksrv_aio_ctx *ctx,
+		struct ublksrv_aio *req);
+
+#define ublksrv_aio_qid(val)  ((val >> 13) & 0x7ff)
+#define ublksrv_aio_tag(val)  (val & 0x1fff)
+
+unsigned ublksrv_aio_pid_tag(unsigned qid, unsigned tag)
+{
+	return tag | (qid << 13);
+}
+
+struct ublksrv_aio {
+	struct ublksrv_io_desc io;
+	union {
+		int res;	/* output */
+		int fd;		/* input */
+	};
+
+	/* reserved 31 ~ 24, bit 23 ~ 13: qid, bit 12 ~ 0: tag */
+	unsigned id;
+	struct ublksrv_aio *next;
+	unsigned long data[0];
+};
+
+struct aio_list {
+	struct ublksrv_aio *head, *tail;
+};
+
+static inline void aio_list_init(struct aio_list *al)
+{
+	al->head = al->tail = NULL;
+}
+
+static inline void aio_list_add(struct aio_list *al, struct ublksrv_aio *io)
+{
+	io->next = NULL;
+
+	if (al->tail)
+		al->tail->next = io;
+	else
+		al->head = io;
+	al->tail = io;
+}
+
+static inline void aio_list_splice(struct aio_list *n,
+		struct aio_list *head)
+{
+	if (!n->head)
+		return;
+
+	if (head->tail)
+		head->tail->next = n->head;
+	else
+		head->head = n->head;
+
+	head->tail = n->tail;
+
+	aio_list_init(n);
+}
+
+static inline int aio_list_empty(const struct aio_list *al)
+{
+	return al->head == NULL;
+}
+
+static inline struct ublksrv_aio *aio_list_pop(struct aio_list *al)
+{
+	struct ublksrv_aio *io = al->head;
+
+	if (io) {
+		al->head = io->next;
+		if (!al->head)
+			al->tail = NULL;
+
+		io->next = NULL;
+	}
+
+	return io;
+}
+
+struct ublksrv_aio_list {
+	pthread_spinlock_t lock;
+	struct aio_list list;
+};
+
+/*
+ * ublksrv_aio_ctx is used to offload IO handling from ublksrv io_uring
+ * context.
+ *
+ * ublksrv_aio_ctx is bound with one single pthread which has to belong
+ * to same process of the io_uring where IO is originated, so we can
+ * support to handle IO from multiple queues of the same device. At
+ * default, ublksrv_aio_ctx supports to handle device wide aio or io
+ * offloading except for UBLKSRV_AIO_QUEUE_WIDE.
+ *
+ * Meantime ublksrv_aio_ctx can be created per each queue, and only handle
+ * IOs from this queue.
+ *
+ * The final io handling in the aio context depends on user's implementation,
+ * either sync or async IO submitting is supported.
+ */
+struct ublksrv_aio_ctx {
+	struct ublksrv_aio_list submit;
+
+	/* per-queue completion list */
+	struct ublksrv_aio_list *complete;
+
+	int efd;		//for wakeup us
+
+#define UBLKSRV_AIO_QUEUE_WIDE	(1U << 0)
+	unsigned int		flags;
+	bool dead;
+
+	struct ublksrv_dev *dev;
+
+	void *ctx_data;
+};
+
+static inline bool ublksrv_aio_ctx_dead(struct ublksrv_aio_ctx *ctx)
+{
+	return ctx->dead;
+}
+
+static inline void ublksrv_aio_init_list(struct ublksrv_aio_list *l)
+{
+	pthread_spin_init(&l->lock, PTHREAD_PROCESS_PRIVATE);
+	aio_list_init(&l->list);
+}
+
+struct ublksrv_aio_ctx *ublksrv_aio_ctx_init(struct ublksrv_dev *dev, unsigned
+		flags);
+void ublksrv_aio_ctx_shutdown(struct ublksrv_aio_ctx *ctx);
+void ublksrv_aio_ctx_deinit(struct ublksrv_aio_ctx *ctx);
+struct ublksrv_aio *ublksrv_aio_alloc_req(struct ublksrv_aio_ctx *ctx,
+		int payload_size);
+void ublksrv_aio_free_req(struct ublksrv_aio_ctx *ctx, struct ublksrv_aio *req);
+void ublksrv_aio_submit_req(struct ublksrv_aio_ctx *ctx,
+		struct ublksrv_aio *req);
+void ublksrv_aio_get_completed_reqs(struct ublksrv_aio_ctx *ctx,
+		const struct ublksrv_queue *q,
+		struct aio_list *al);
+int ublksrv_aio_submit_worker(struct ublksrv_aio_ctx *ctx,
+		ublksrv_aio_submit_fn *fn, struct aio_list *submitted);
+void ublksrv_aio_complete_worker(struct ublksrv_aio_ctx *ctx,
+		struct aio_list *completed);
+void ublksrv_aio_handle_event(struct ublksrv_aio_ctx *ctx,
+		struct ublksrv_queue *q);

--- a/include/ublksrv_priv.h
+++ b/include/ublksrv_priv.h
@@ -31,12 +31,6 @@ static inline bool ublksrv_io_done(struct ublk_io *io)
 	return io->flags & UBLKSRV_IO_FREE;
 }
 
-static inline struct ublksrv_queue *ublksrv_get_queue(const struct ublksrv_dev *dev,
-		int q_id)
-{
-	return dev->__queues[q_id];
-}
-
 static inline int is_target_io(__u64 user_data)
 {
 	return (user_data & (1ULL << 63)) != 0;

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -6,7 +6,8 @@ libublksrv_la_SOURCES = \
 	ublksrv_cmd.c \
 	ublksrv_json.cpp \
 	ublksrv.c \
-	utils.c
+	utils.c \
+	ublksrv_aio.c
 libublksrv_la_CFLAGS = \
 	$(WARNING_CFLAGS) \
 	$(LIBURING_CFLAGS) \

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -853,3 +853,9 @@ int ublksrv_process_io(struct ublksrv_queue *q)
 
 	return reapped;
 }
+
+struct ublksrv_queue *ublksrv_get_queue(const struct ublksrv_dev *dev,
+		int q_id)
+{
+	return dev->__queues[q_id];
+}

--- a/lib/ublksrv_aio.c
+++ b/lib/ublksrv_aio.c
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT or LGPL-2.1-only
+
+#define _GNU_SOURCE
+#include "ublksrv_aio.h"
+#include <sys/epoll.h>
+
+static inline void aio_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    vsyslog(LOG_INFO, fmt, ap);
+}
+
+int ublksrv_aio_submit_worker(struct ublksrv_aio_ctx *ctx,
+		ublksrv_aio_submit_fn *fn, struct aio_list *done)
+{
+	struct ublksrv_aio *req = NULL;
+	unsigned long long data;
+	struct aio_list sl;
+	int total = 0;
+	bool more;
+
+	aio_list_init(&sl);
+again:
+	pthread_spin_lock(&ctx->submit.lock);
+	aio_list_splice(&ctx->submit.list, &sl);
+	pthread_spin_unlock(&ctx->submit.lock);
+
+	while (req = aio_list_pop(&sl)) {
+		int ret = fn(ctx, req);
+
+		/*
+		 * submission failed, so set result for this request,
+		 * otherwise it is user's responsibility to set correct
+		 * ->res after the request is completed
+		 */
+		if (ret < 0) {
+			req->res = ret;
+			aio_log("ublk aio submission fail, %d\n", ret);
+		}
+		total += 1;
+		if (ret && done)
+			aio_list_add(done, req);
+	}
+
+	read(ctx->efd, &data, 8);
+
+	pthread_spin_lock(&ctx->submit.lock);
+	more = !aio_list_empty(&ctx->submit.list);
+	pthread_spin_unlock(&ctx->submit.lock);
+	if (more)
+		goto again;
+
+	return total;
+}
+
+static void move_to_queue_complete_list(struct ublksrv_aio_ctx *ctx,
+		struct ublksrv_queue *q, struct aio_list *list)
+{
+	struct ublksrv_aio_list *compl;
+
+	if (aio_list_empty(list))
+		return;
+
+	compl = &ctx->complete[q->q_id];
+	pthread_spin_lock(&compl->lock);
+	aio_list_splice(list, &compl->list);
+	pthread_spin_unlock(&compl->lock);
+}
+
+void ublksrv_aio_complete_worker(struct ublksrv_aio_ctx *ctx,
+		struct aio_list *completed)
+{
+	struct aio_list this, others;
+	struct ublksrv_aio *req = NULL;
+	struct ublksrv_queue *this_q = NULL;
+
+	if (aio_list_empty(completed))
+		return;
+
+	if (ctx->flags & UBLKSRV_AIO_QUEUE_WIDE) {
+		this_q = ublksrv_get_queue(ctx->dev,
+				ublksrv_aio_qid(completed->head->id));
+		move_to_queue_complete_list(ctx, this_q, completed);
+		ublksrv_queue_send_event(this_q);
+		return;
+	}
+
+	aio_list_init(&this);
+	aio_list_init(&others);
+
+	while (!aio_list_empty(completed)) {
+		struct ublksrv_aio_list *compl;
+
+		this_q = ublksrv_get_queue(ctx->dev,
+				ublksrv_aio_qid(completed->head->id));
+
+		while (req = aio_list_pop(completed)) {
+			struct ublksrv_queue *q = ublksrv_get_queue(ctx->dev,
+					ublksrv_aio_qid(req->id));
+
+			if (q == this_q)
+				aio_list_add(&this, req);
+			else
+				aio_list_add(&others, req);
+		}
+
+		move_to_queue_complete_list(ctx, this_q, &this);
+		ublksrv_queue_send_event(this_q);
+		aio_list_splice(&others, completed);
+	}
+}
+
+struct ublksrv_aio_ctx *ublksrv_aio_ctx_init(struct ublksrv_dev *dev, unsigned
+		flags)
+{
+	unsigned nr_hw_queues = dev->ctrl_dev->dev_info.nr_hw_queues;
+	struct ublksrv_aio_ctx *ctx;
+	int ret, i;
+
+	if (!(dev->ctrl_dev->dev_info.ublksrv_flags & UBLKSRV_F_NEED_EVENTFD))
+		return NULL;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx)
+		return NULL;
+
+	ctx->complete = malloc(nr_hw_queues * sizeof(struct ublksrv_aio_list));
+	if (!ctx->complete) {
+		free(ctx);
+		return NULL;
+	}
+	for (i = 0; i < nr_hw_queues; i++)
+		ublksrv_aio_init_list(&ctx->complete[i]);
+
+	ublksrv_aio_init_list(&ctx->submit);
+
+	ctx->flags = flags;
+	ctx->dev = dev;
+	ctx->dead = false;
+	ctx->efd = eventfd(0, O_NONBLOCK);
+
+	return ctx;
+}
+
+/* called before pthread_join() of the pthread context */
+void ublksrv_aio_ctx_shutdown(struct ublksrv_aio_ctx *ctx)
+{
+	unsigned long long data = 1;
+
+	ctx->dead = true;
+	write(ctx->efd, &data, 8);
+}
+
+/* called afer pthread_join() of the pthread context returns */
+void ublksrv_aio_ctx_deinit(struct ublksrv_aio_ctx *ctx)
+{
+	close(ctx->efd);
+	free(ctx);
+}
+
+struct ublksrv_aio *ublksrv_aio_alloc_req(struct ublksrv_aio_ctx *ctx,
+		int payload_size)
+{
+	const int sz = (sizeof(struct ublksrv_aio) + payload_size + 7) & ~ 0x7;
+
+	return (struct ublksrv_aio *)calloc(1, sz);
+}
+
+void ublksrv_aio_free_req(struct ublksrv_aio_ctx *ctx, struct ublksrv_aio *req)
+{
+	free(req);
+}
+
+void ublksrv_aio_submit_req(struct ublksrv_aio_ctx *ctx,
+		struct ublksrv_aio *req)
+{
+	unsigned long long data = 1;
+
+	pthread_spin_lock(&ctx->submit.lock);
+	aio_list_add(&ctx->submit.list, req);
+	pthread_spin_unlock(&ctx->submit.lock);
+
+	write(ctx->efd, &data, 8);
+}
+
+void ublksrv_aio_get_completed_reqs(struct ublksrv_aio_ctx *ctx,
+		const struct ublksrv_queue *q,
+		struct aio_list *al)
+{
+	struct ublksrv_aio_list *compl = &ctx->complete[q->q_id];
+
+	pthread_spin_lock(&compl->lock);
+	aio_list_splice(&compl->list, al);
+	pthread_spin_unlock(&compl->lock);
+}
+
+void ublksrv_aio_handle_event(struct ublksrv_aio_ctx *ctx,
+		struct ublksrv_queue *q)
+{
+	struct aio_list al;
+	int cnt = 0;
+
+	aio_list_init(&al);
+	do {
+		struct ublksrv_aio *req;
+
+		ublksrv_aio_get_completed_reqs(ctx, q, &al);
+
+		cnt = 0;
+		while (req = aio_list_pop(&al)) {
+			cnt++;
+			ublksrv_complete_io(q, ublksrv_aio_tag(req->id),
+					req->res);
+			ublksrv_aio_free_req(ctx, req);
+		}
+		aio_list_init(&al);
+	} while (cnt);
+
+	ublksrv_queue_handled_event(q);
+}


### PR DESCRIPTION
Add interfaces for offloading io handling into non-io_uring context, and it is ublksrv's aio.

For the following reasons:

    1) in io_uring implementation, fallocate() and fsync() is actually sync
    interface, sometimes fsync() is required to order IO, which may slow
    down the whole io uring
    
    2) sometimes sqe may be run out of space
    
    3) the single io_uring context may be saturated, such as compression,
    decompression, encrypt/decrypt, ...
    
    4) some implementation chooses non-io_uring io handling, such as
    ublk-nbd.

The added interfaces will simplify io offloading implementation a lot. With these interface, demo_event now supports both null and loop target, meantime supports both sync io and io_uring handling.
