### PR TITLE
ublksrv: Add kernel version and g++ options check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,4 +69,35 @@ AC_CONFIG_FILES([Makefile
                  tests/Makefile
                  ublksrv.pc])
 
+#
+# Check if g++ supports -fcoroutines -std=c++20
+#
+AC_LANG_PUSH([C++])
+CXXFLAGS_save=$CXXFLAGS
+CXXFLAGS="$CXXFLAGS -fcoroutines -std=c++20"
+T001_PROGRAM="
+#include <coroutine>
+int main(void) {
+	return 0;
+}
+"
+AC_MSG_CHECKING([whether $CXX supports -fcoroutines -std=c++20])
+AC_COMPILE_IFELSE(
+	[AC_LANG_SOURCE([$T001_PROGRAM])],
+	[AC_MSG_RESULT([yes])],
+	[AC_MSG_FAILURE([no])]
+)
+
+CXXFLAGS=$CXXFLAGS_save
+AC_LANG_POP([C++])
+
+#
+# Only support kernel 5.19 and beyond
+#
+linux_kernel_ver=$(uname -r)
+AX_COMPARE_VERSION($linux_kernel_ver, [ge], [5.19],
+    [AC_MSG_NOTICE([checking for kernel version >= 5.19.X. Found... $linux_kernel_ver])],
+    [AC_MSG_ERROR([Expected Kernel Version >= 5.19.X. Found... $linux_kernel_ver]),[1]])
+
+
 AC_OUTPUT


### PR DESCRIPTION
This patch updates configure.ac to add
kernel version checks and g++ checks
mandatory. This is because if the criteria
is not met the build will fail during actual
make.

This make minimum kernel version as 5.19.X.
Anything lesser than 5.19 the build will stop
with failure.

This patch also confirms if g++/c++ supports
CFLAGS option of "-fcoroutines -std=c++20".
If not supported the build stops with failure.

Signed-off-by: H Arshad <harshad1024@proton.me>