### PR TITLE
ublksrv_tgt: fix potential buffer overflow when printing usage in help

### DIFF
--- a/ublksrv_tgt.cpp
+++ b/ublksrv_tgt.cpp
@@ -588,9 +588,9 @@ static void collect_tgt_types(unsigned int idx,
 
 	if (idx > 0)
 		data->pos += snprintf(data->names + data->pos,
-				4096 - data->pos, "|");
-	data->pos += snprintf(data->names + data->pos, 4096 - data->pos,
-			"%s", type->name);
+                  sizeof(data->names) - data->pos, "|");
+	data->pos += snprintf(data->names + data->pos,
+                sizeof(data->names) - data->pos, "%s", type->name);
 }
 
 static void show_tgt_add_usage(unsigned int idx,
@@ -606,9 +606,9 @@ static void cmd_dev_add_usage(char *cmd)
 		.pos = 0,
 	};
 
-	data.pos += snprintf(data.names + data.pos, 4096 - data.pos, "{");
+	data.pos += snprintf(data.names + data.pos, sizeof(data.names) - data.pos, "{");
 	ublksrv_for_each_tgt_type(collect_tgt_types, &data);
-	data.pos += snprintf(data.names + data.pos, 4096 - data.pos, "}");
+	data.pos += snprintf(data.names + data.pos, sizeof(data.names) - data.pos, "}");
 
 	printf("%s add -t %s -n DEV_ID -q NR_HW_QUEUES -d QUEUE_DEPTH "
 			"-u URING_COMP -g NEED_GET_DATA\n",


### PR DESCRIPTION
Hi Ming, thanks for a great project!

After figuring out how to build on my (outdated) ubuntu-box
```
export PTHREAD_LIBS="-lpthread"
export CXX=/usr/bin/gcc-11
export LDFLAGS="-lstdc++"
autoreconf -i
./configure
make
```

I noticed this warning:
```
In function ‘int snprintf(char*, size_t, const char*, ...)’,
    inlined from ‘void cmd_dev_add_usage(char*)’ at ublksrv_tgt.cpp:609:22:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: warning: ‘int __builtin___snprintf_chk(char*, long unsigned int, int, long unsigned int, const char*, ...)’ specified bound 4096 exceeds destination size 4092 [-Wstringop-overflow=]
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |                                    __bos (__s), __fmt, __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

.. and that the tool core dumped 
```
#./ublk help
*** buffer overflow detected ***: terminated
Aborted (core dumped)
```

Turns out that the string buffer data.names is not 4096 bytes long, so this patch corrects the length handed to snprintfs and removes the hard coding to avoid any future issues if more members are added to the struct.

Thanks,
Hans