### PR TITLE
[V3] ublk: add USER_RECOVERY support 

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -317,7 +317,10 @@ struct ublksrv_tgt_type {
 	unsigned pad;
 	const char *name;
 
-	unsigned long reserved[8];
+	/* recovery this target */
+	int (*recovery_tgt)(struct ublksrv_dev *, int type);
+
+	unsigned long reserved[7];
 };
 
 struct ublksrv_dev {

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -109,8 +109,15 @@ struct ublksrv_ctrl_dev {
 	 */
 	const char *run_dir;
 
-	int tgt_argc;
-	char **tgt_argv;
+	union {
+		/* used by ->init_tgt() */
+		struct {
+			int tgt_argc;
+			char **tgt_argv;
+		};
+		/* used by ->recovery_tgt() */
+		const char *recovery_jbuf;
+	};
 
 	cpu_set_t *queues_cpuset;
 
@@ -371,6 +378,9 @@ extern int ublksrv_ctrl_set_params(struct ublksrv_ctrl_dev *dev,
 		struct ublk_params *params);
 extern int ublksrv_ctrl_get_params(struct ublksrv_ctrl_dev *dev,
 		struct ublk_params *params);
+extern int ublksrv_ctrl_start_recovery(struct ublksrv_ctrl_dev *dev);
+extern int ublksrv_ctrl_end_recovery(struct ublksrv_ctrl_dev *dev,
+		int daemon_pid);
 
 extern struct ublksrv_dev *ublksrv_dev_init(const struct ublksrv_ctrl_dev *
 		ctrl_dev);

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -396,6 +396,11 @@ extern int ublksrv_json_read_queue_info(const char *jbuf, int qid,
 		unsigned *tid, char *affinity_buf, int len);
 extern int ublksrv_json_read_target_info(const char *jbuf, char *tgt_buf,
 		int len);
+extern int ublksrv_json_read_target_str_info(const char *jbuf, int len,
+		const char *name, char *val);
+
+extern int ublksrv_json_read_target_ulong_info(const char *jbuf,
+		const char *name, long *val);
 extern int ublksrv_json_write_target_str_info(char *jbuf, int len,
 		const char *name, const char *val);
 extern int ublksrv_json_write_target_long_info(char *jbuf, int len,

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -69,7 +69,15 @@ static int __ublksrv_tgt_init(struct ublksrv_dev *dev, const char *type_name,
 
 	optind = 0;     /* so that we can parse our arguments */
 	tgt->ops = ops;
-	ret = ops->init_tgt(dev, type, argc, argv);
+
+	if (dev->ctrl_dev->dev_info.state != UBLK_S_DEV_QUIESCED)
+		ret = ops->init_tgt(dev, type, argc, argv);
+	else {
+		if (ops->recovery_tgt)
+			ret = ops->recovery_tgt(dev, type);
+		else
+			ret = -ENOTSUP;
+	}
 	if (ret) {
 		tgt->ops = NULL;
 		return ret;

--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -256,6 +256,8 @@ static const char *ublksrv_dev_state_desc(struct ublksrv_ctrl_dev *dev)
 		return "DEAD";
 	case UBLK_S_DEV_LIVE:
 		return "LIVE";
+	case UBLK_S_DEV_QUIESCED:
+		return "QUIESCED";
 	default:
 		return "UNKNOWN";
 	};
@@ -323,4 +325,30 @@ int ublksrv_ctrl_get_params(struct ublksrv_ctrl_dev *dev,
 	params->len = sizeof(*params);
 
 	return __ublksrv_ctrl_cmd(dev, &data);
+}
+
+int ublksrv_ctrl_start_recovery(struct ublksrv_ctrl_dev *dev)
+{
+	struct ublksrv_ctrl_cmd_data data = {
+		.cmd_op	= UBLK_CMD_START_USER_RECOVERY,
+		.flags = 0,
+	};
+	int ret;
+
+	ret = __ublksrv_ctrl_cmd(dev, &data);
+	return ret;
+}
+
+int ublksrv_ctrl_end_recovery(struct ublksrv_ctrl_dev *dev, int daemon_pid)
+{
+	struct ublksrv_ctrl_cmd_data data = {
+		.cmd_op	= UBLK_CMD_END_USER_RECOVERY,
+		.flags = CTRL_CMD_HAS_DATA,
+	};
+	int ret;
+
+	dev->dev_info.ublksrv_pid = data.data[0] = daemon_pid;
+
+	ret = __ublksrv_ctrl_cmd(dev, &data);
+	return ret;
 }

--- a/lib/ublksrv_json.cpp
+++ b/lib/ublksrv_json.cpp
@@ -147,6 +147,54 @@ int ublksrv_json_dump_params(const char *jbuf)
 	return 0;
 }
 
+int ublksrv_json_read_target_str_info(const char *jbuf, int len,
+		const char *name, char *val)
+{
+	json j;
+	std::string s;
+	int j_len;
+
+	parse_json(j, jbuf);
+
+	if (!j.contains("target"))
+		return -EINVAL;
+
+	auto tj = j["target"];
+
+	if (!tj.contains(name))
+		return -EINVAL;
+
+	std::string str = tj[std::string(name)];
+	if (str.length() < len) {
+		strcpy(val, str.c_str());
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
+int ublksrv_json_read_target_ulong_info(const char *jbuf,
+		const char *name, long *val)
+{
+	json j;
+	std::string s;
+	int j_len;
+
+	parse_json(j, jbuf);
+
+	if (!j.contains("target"))
+		return -EINVAL;
+
+	auto tj = j["target"];
+
+	if (!tj.contains(name))
+		return -EINVAL;
+
+	*val = tj[std::string(name)];
+
+	return 0;
+}
+
 int ublksrv_json_write_target_str_info(char *jbuf, int len,
 		const char *name, const char *val)
 {

--- a/tests/common/fio_common
+++ b/tests/common/fio_common
@@ -174,6 +174,15 @@ __ublk_dev_id() {
 	echo "$dev_id"
 }
 
+__ublk_get_pid() {
+	local dev=$1
+	local dev_id=`__ublk_dev_id $dev`
+
+	eval $UBLK list -n $dev_id > ${UBLK_TMP}
+	pid=`cat ${UBLK_TMP} | grep "pid" | awk '{print $7}'`
+	echo $pid
+}
+
 __ublk_get_queue_tid() {
 	local dev=$1
 	local qid=$2
@@ -230,6 +239,16 @@ __create_ublk_dev()
 	[ ${id} == "-" ] && echo "no free ublk device nodes" && exit -1
 	eval $UBLK add ${T_TYPE_PARAMS} -n $id > /dev/null 2>&1
 	echo "/dev/ublkb${id}"
+}
+
+__recover_ublk_dev()
+{
+	local dev=$1
+	local dev_id=`__ublk_dev_id $dev`
+
+	eval $UBLK recover -n $dev_id
+	RES=$?
+	echo $RES
 }
 
 __get_cpu_utils()

--- a/tests/common/fio_common
+++ b/tests/common/fio_common
@@ -303,6 +303,11 @@ __run_dev_perf()
 	__remove_ublk_dev $DEV
 }
 
+_create_null_image()
+{
+	echo ""
+}
+
 _create_image()
 {
 	local type=$1
@@ -310,6 +315,11 @@ _create_image()
 	shift 1
 
 	eval _create_${type}_image $@
+}
+
+_remove_null_image()
+{
+	echo "nothing" > /dev/null
 }
 
 _remove_image()

--- a/tests/generic/004
+++ b/tests/generic/004
@@ -42,10 +42,6 @@ ublk_run_delete_test()
 
 file=`_create_loop_image "data" 1G`
 
-for NEED_GET_DATA in `seq 0 1`; do
-	ublk_run_delete_test
-done
-
 RECOVERY=1
 for RECOVERY_REISSUE in `seq 0 1`; do
 	ublk_run_delete_test

--- a/tests/generic/004
+++ b/tests/generic/004
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT or GPL-2.0-only
+#!/bin/bash
+
+. common/fio_common
+. common/loop_common
+
+echo -e "\trun fio with kill ubq_deamon and delete(NOWAIT) ublk-loop test"
+
+BS=4k
+RW=rw
+JOBS=4
+QUEUES=4
+RT=$TRUNTIME
+LOOPS=4
+URING_COMP=1
+NEED_GET_DATA=1
+RECOVERY=0
+RECOVERY_REISSUE=0
+
+
+ublk_run_delete_test()
+{
+	for CNT in `seq $LOOPS`; do
+		export T_TYPE_PARAMS="-t loop -q $QUEUES -u $URING_COMP -g $NEED_GET_DATA -r $RECOVERY -i $RECOVERY_REISSUE -f $file"
+
+		DEV=`__create_ublk_dev`
+		echo -e "\trun fio on $DEV(ublk $T_TYPE_PARAMS) with deleting dev $CNT"
+		__run_fio_libaio $DEV $BS $RW $JOBS $RT > /dev/null 2 >& 1 &
+		sleep 2
+		queue_tid=`__ublk_get_queue_tid $DEV 0`
+		kill -9 $queue_tid
+		RES=`__remove_ublk_dev_return $DEV`
+		if [ $RES -ne 0 ]; then
+				echo -e "\tdelete $DEV failed"
+				ps -eLf | grep ublk
+				(cd /sys/kernel/debug/block/`basename $DEV` && find . -type f -exec grep -aH . {} \;)
+				break
+		fi
+		wait
+	done
+}
+
+file=`_create_loop_image "data" 1G`
+
+for NEED_GET_DATA in `seq 0 1`; do
+	ublk_run_delete_test
+done
+
+RECOVERY=1
+for RECOVERY_REISSUE in `seq 0 1`; do
+	ublk_run_delete_test
+done
+
+_remove_loop_image $file

--- a/tests/generic/005
+++ b/tests/generic/005
@@ -2,6 +2,8 @@
 #!/bin/bash
 
 . common/fio_common
+. common/loop_common
+. common/qcow2_common
 
 echo -e "\trun fio with dev recovery, type 1:"
 echo -e "\t(1)kill all ubq_deamon, (2)recover with new ubq_daemon, (3)delete dev"
@@ -11,7 +13,7 @@ RW=rw
 JOBS=4
 QUEUES=2
 RT=$TRUNTIME*2
-LOOPS=4
+LOOPS=1
 URING_COMP=1
 NEED_GET_DATA=1
 RECOVERY=1
@@ -19,8 +21,23 @@ RECOVERY_REISSUE=0
 
 ublk_run_recover_test()
 {
+	local type=$1
+	local file=`_create_image $type "null" 256M`
+
+	if [ "$type" == "null" ]; then
+		local backing=""
+	else
+		local backing="-f $file"
+	fi
+
+	if [ "$type" == "qcow2" ]; then
+		QUEUES=1
+	else
+		QUEUES=2
+	fi
+
 	for CNT in `seq $LOOPS`; do
-		export T_TYPE_PARAMS="-t null -q $QUEUES -u $URING_COMP -g $NEED_GET_DATA -r $RECOVERY -i $RECOVERY_REISSUE"
+		export T_TYPE_PARAMS="-t $type -q $QUEUES -u $URING_COMP -g $NEED_GET_DATA -r $RECOVERY -i $RECOVERY_REISSUE $backing"
 		DEV=`__create_ublk_dev`
 		echo -e "\trun fio with killing $DEV(ublk $T_TYPE_PARAMS) queue daemon $CNT"
 		__run_fio_libaio $DEV $BS $RW $JOBS $RT > /dev/null 2 >& 1 &
@@ -55,8 +72,11 @@ ublk_run_recover_test()
 		wait
 		sleep 3
 	done
+	_remove_image ${type} $file
 }
 
-for RECOVERY_REISSUE in `seq 0 1`; do
-		ublk_run_recover_test
+for TGT in $ALL_TGTS; do
+	for RECOVERY_REISSUE in `seq 0 1`; do
+			ublk_run_recover_test $TGT
+	done
 done

--- a/tests/generic/005
+++ b/tests/generic/005
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT or GPL-2.0-only
+#!/bin/bash
+
+. common/fio_common
+
+echo -e "\trun fio with dev recovery, type 1:"
+echo -e "\t(1)kill all ubq_deamon, (2)recover with new ubq_daemon, (3)delete dev"
+
+BS=4k
+RW=rw
+JOBS=4
+QUEUES=2
+RT=$TRUNTIME*2
+LOOPS=4
+URING_COMP=1
+NEED_GET_DATA=1
+RECOVERY=1
+RECOVERY_REISSUE=0
+
+ublk_run_recover_test()
+{
+	for CNT in `seq $LOOPS`; do
+		export T_TYPE_PARAMS="-t null -q $QUEUES -u $URING_COMP -g $NEED_GET_DATA -r $RECOVERY -i $RECOVERY_REISSUE"
+		DEV=`__create_ublk_dev`
+		echo -e "\trun fio with killing $DEV(ublk $T_TYPE_PARAMS) queue daemon $CNT"
+		__run_fio_libaio $DEV $BS $RW $JOBS $RT > /dev/null 2 >& 1 &
+		sleep 2
+		pid=`__ublk_get_pid $DEV`
+		kill -9 $pid
+		sleep 2
+		secs=0
+		while [ $secs -lt 10 ]; do
+			state=`__ublk_get_dev_state $DEV 0`
+			[ "$state" == "QUIESCED" ] && break
+			sleep 1
+			let secs++
+		done
+		secs=0
+		while [ $secs -lt 10 ]; do
+			RES=`__recover_ublk_dev $DEV`
+			[ $RES -eq 0 ] && break
+			sleep 1
+			let secs++
+		done
+		if [ $RES -ne 0 ]; then
+				echo -e "\trecover $DEV failed"
+				exit -1
+		fi
+		sleep 2
+		RES=`__remove_ublk_dev_return $DEV`
+		if [ $RES -ne 0 ]; then
+				echo -e "\tdelete $DEV failed"
+				exit -1
+		fi
+		wait
+		sleep 3
+	done
+}
+
+for RECOVERY_REISSUE in `seq 0 1`; do
+		ublk_run_recover_test
+done

--- a/tests/generic/006
+++ b/tests/generic/006
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT or GPL-2.0-only
+#!/bin/bash
+
+. common/fio_common
+
+echo -e "\trun fio with dev recovery, type 2:"
+echo -e "\t(1)kill all ubq_deamon, (2)recover with new ubq_daemon, (3)kill all ubq_deamon, (4)delete dev"
+
+BS=4k
+RW=rw
+JOBS=4
+QUEUES=2
+RT=$TRUNTIME*2
+LOOPS=4
+URING_COMP=1
+NEED_GET_DATA=1
+RECOVERY=1
+RECOVERY_REISSUE=0
+
+ublk_run_recover_kill_test()
+{
+	for CNT in `seq $LOOPS`; do
+		export T_TYPE_PARAMS="-t null -q $QUEUES -u $URING_COMP -g $NEED_GET_DATA -r $RECOVERY -i $RECOVERY_REISSUE"
+		DEV=`__create_ublk_dev`
+		echo -e "\trun fio with killing $DEV(ublk $T_TYPE_PARAMS) queue daemon $CNT"
+		__run_fio_libaio $DEV $BS $RW $JOBS $RT > /dev/null 2 >& 1 &
+		sleep 2
+		pid1=`__ublk_get_pid $DEV`
+		kill -9 $pid1
+		sleep 2
+		secs=0
+		while [ $secs -lt 10 ]; do
+			state=`__ublk_get_dev_state $DEV`
+			[ "$state" == "QUIESCED" ] && break
+			sleep 1
+			let secs++
+		done
+		secs=0
+		while [ $secs -lt 10 ]; do
+			RES=`__recover_ublk_dev $DEV`
+			[ $RES -eq 0 ] && break
+			sleep 1
+			let secs++
+		done
+		if [ $RES -ne 0 ]; then
+				echo -e "\trecover $DEV failed"
+				exit -1
+		fi
+		sleep 2
+        pid2=`__ublk_get_pid $DEV`
+		kill -9 $pid2
+		sleep 2
+		RES=`__remove_ublk_dev_return $DEV`
+		if [ $RES -ne 0 ]; then
+				echo -e "\tdelete $DEV failed"
+				exit -1
+		fi
+		wait
+		sleep 3
+	done
+}
+
+for RECOVERY_REISSUE in `seq 0 1`; do
+		ublk_run_recover_kill_test
+done

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -32,7 +32,7 @@ run_test_grp() {
 
 run_test_all() {
 	local D=$1
-	local GRPS="generic null loop qcow2"
+	local GRPS="generic $ALL_TGTS"
 	for G in $GRPS; do
 			run_test_grp $D/$G
 	done
@@ -47,6 +47,7 @@ if [ "${TDIR:0:1}" != "/" ]; then
 	TDIR=`dirname $PWD`/${TDIR}
 fi
 
+export ALL_TGTS="null loop qcow2"
 export TRUNTIME=$2
 export UBLK_TMP_DIR=$TDIR
 export T_TYPE_PARAMS=""


### PR DESCRIPTION
Hi Ziyang,

v3 is against your v2:
1) support to recovery all targets
2) rebase one master branch, since tests is cleaned up
3) remove the change on existed tests(generic/001, generic/002, generic/003), and just let generic/004-006 cover recover tests; also
extend generic/005 to cover recovery test on all targets.

Please review, and if you are fine, I will pull them into master.

Thanks,



