### PR TITLE
Move SPDX comment line in scripts

### DIFF
--- a/tests/common/fio_common
+++ b/tests/common/fio_common
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 declare -A TEST_RUN
 

--- a/tests/common/loop_common
+++ b/tests/common/loop_common
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 export LO_IMG_SZ=1G
 

--- a/tests/debug/test_dev
+++ b/tests/debug/test_dev
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 #
 #usage:
 #	export UBLK_DBG_DEV=/dev/vdc; make test T=debug/test_dev

--- a/tests/generic/001
+++ b/tests/generic/001
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/generic/002
+++ b/tests/generic/002
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 

--- a/tests/generic/003
+++ b/tests/generic/003
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/loop/001
+++ b/tests/loop/001
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/loop/002
+++ b/tests/loop/002
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/loop/003
+++ b/tests/loop/003
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/loop/004
+++ b/tests/loop/004
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/loop/005
+++ b/tests/loop/005
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/loop/007
+++ b/tests/loop/007
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/null/001
+++ b/tests/null/001
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 

--- a/tests/null/002
+++ b/tests/null/002
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 

--- a/tests/null/004
+++ b/tests/null/004
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 

--- a/tests/null/005
+++ b/tests/null/005
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 

--- a/tests/qcow2/001
+++ b/tests/qcow2/001
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 
 . common/fio_common
 . common/qcow2_common

--- a/tests/qcow2/002
+++ b/tests/qcow2/002
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 
 . common/fio_common
 . common/qcow2_common

--- a/tests/qcow2/021
+++ b/tests/qcow2/021
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 
 . common/fio_common
 . common/qcow2_common

--- a/tests/qcow2/022
+++ b/tests/qcow2/022
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 
 . common/fio_common
 . common/qcow2_common

--- a/tests/qcow2/040
+++ b/tests/qcow2/040
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 
 . common/fio_common
 . common/qcow2_common

--- a/tests/qcow2/041
+++ b/tests/qcow2/041
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
 
 . common/fio_common
 . common/qcow2_common

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 DIR=$(cd "$(dirname "$0")";pwd)
 


### PR DESCRIPTION
While trying to run the tests present in this project, I saw syntax errors. I realized that this was because my default shell is `zsh` (not `bash`); the scripts are supposed to run under `bash`, but this wasn't happening because the `#!/bin/bash` comment lines were moved below SPDX comment lines. (As a result, the `#!` line was just treated as a plain-old comment.)

This change rearranges these comment lines to address the above issue.

(For what it's worth the kernel's [license rules](https://www.kernel.org/doc/Documentation/process/license-rules.rst) address this particular case -- indicating that, for scripts, the SPDX lines should be placed below the `#!` line.)