### PR TITLE
Targeted improvements for failure paths (error messages, cleanup)

### DIFF
--- a/demo_event.c
+++ b/demo_event.c
@@ -374,17 +374,22 @@ static int demo_event_io_handler(struct ublksrv_ctrl_dev *ctrl_dev)
 
 	info_array = (struct demo_queue_info *)
 		calloc(sizeof(struct demo_queue_info), dinfo->nr_hw_queues);
+	if (!info_array)
+		return -ENOMEM;
 
 	dev = ublksrv_dev_init(ctrl_dev);
-	if (!dev)
+	if (!dev) {
+		free(info_array);
 		return -ENOMEM;
+	}
 	this_dev = dev;
 
 
 	aio_ctx = ublksrv_aio_ctx_init(dev, 0);
 	if (!aio_ctx) {
 		fprintf(stderr, "dev %d call ublk_aio_ctx_init failed\n", dev_id);
-		return -ENOMEM;
+		ret = -ENOMEM;
+		goto fail;
 	}
 
 	if (!use_aio)

--- a/demo_null.c
+++ b/demo_null.c
@@ -105,10 +105,14 @@ static int demo_null_io_handler(struct ublksrv_ctrl_dev *ctrl_dev)
 
 	info_array = (struct demo_queue_info *)
 		calloc(sizeof(struct demo_queue_info), dinfo->nr_hw_queues);
+	if (!info_array)
+		return -ENOMEM;
 
 	dev = ublksrv_dev_init(ctrl_dev);
-	if (!dev)
+	if (!dev) {
+		free(info_array);
 		return -ENOMEM;
+	}
 
 	for (i = 0; i < dinfo->nr_hw_queues; i++) {
 		info_array[i].dev = dev;

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -148,7 +148,10 @@ const struct ublksrv_tgt_type *ublksrv_find_tgt_type(const char *name)
 	int i;
 
 	for (i = 0; i < UBLKSRV_TGT_TYPE_MAX; i++) {
-                const struct ublksrv_tgt_type  *type = tgt_list[i];
+		const struct ublksrv_tgt_type *type = tgt_list[i];
+
+		if (type == NULL)
+			continue;
 
 		if (!strcmp(type->name, name))
 			return type;

--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -101,7 +101,7 @@ struct ublksrv_ctrl_dev *ublksrv_ctrl_init(struct ublksrv_dev_data *data)
 
 	dev->ctrl_fd = open(CTRL_DEV, O_RDWR);
 	if (dev->ctrl_fd < 0) {
-		fprintf(stderr, "conrol dev %s can't be opened\n", CTRL_DEV);
+		fprintf(stderr, "control dev %s can't be opened: %m\n", CTRL_DEV);
 		exit(dev->ctrl_fd);
 	}
 


### PR DESCRIPTION
While experimenting with this project, I encountered some errors (most were user error on my part). I've put together this batch of targeted changes to add more detail to some of the error messages I encountered, and to address issues with potential leaks and uninitialized variables that I encountered in other cases.

Specifically:

* `demo_event.c` and `demo_null.c` had some minor potential leaks in a few failure paths.
* Trying to add a device with an unknown type resulted in a `NULL` dereference.
* Added error messages in a few cases that failed silently (e.g., no device type given on the command line).
* Added `errno`/return value to a few error messages (most notably, the error that shows up if `/dev/ublk-control` can't be opened)
* Tweaked logic in `main` to be able to display command usage help in more cases.

Please do let me know if you'd prefer that any of this get split up into separate changes, or really any feedback you have. I'm new to using this project and looking to learn. (Thanks!)