### PR TITLE
Remove unused variables, labels, functions

### DIFF
--- a/demo_null.c
+++ b/demo_null.c
@@ -95,9 +95,7 @@ static void demo_null_set_parameters(struct ublksrv_ctrl_dev *cdev,
 
 static int demo_null_io_handler(struct ublksrv_ctrl_dev *ctrl_dev)
 {
-	int dev_id = ctrl_dev->dev_info.dev_id;
 	int ret, i;
-	char buf[32];
 	struct ublksrv_dev *dev;
 	struct demo_queue_info *info_array;
 	void *thread_ret;
@@ -145,7 +143,6 @@ static int demo_null_io_handler(struct ublksrv_ctrl_dev *ctrl_dev)
 
 static int ublksrv_start_daemon(struct ublksrv_ctrl_dev *ctrl_dev)
 {
-	int cnt = 0, daemon_pid;
 	int ret;
 
 	if (ublksrv_ctrl_get_affinity(ctrl_dev) < 0)
@@ -222,7 +219,6 @@ int main(int argc, char *argv[])
 		.flags = 0,
 	};
 	struct ublksrv_ctrl_dev *dev;
-	char *type = NULL;
 	int ret;
 	static const struct option longopts[] = {
 		{ "buf",		1,	NULL, 'b' },

--- a/qcow2/qcow2.cpp
+++ b/qcow2/qcow2.cpp
@@ -759,7 +759,6 @@ Qcow2L2Table *Qcow2ClusterMapping::create_and_add_l2(const qcow2_io_ctx_t &ioc,
 		u64 offset)
 {
 	const unsigned idx = l1_idx(offset);
-	int ret;
 	u64 l1_entry = state.l1_table.get_entry(idx);
 	u64 l2_cluster = -1;
 	struct ublksrv_queue *q = ublksrv_get_queue(state.dev, ioc.get_qid());
@@ -933,7 +932,6 @@ u64 Qcow2ClusterMapping::__map_cluster(const qcow2_io_ctx_t &ioc,
 			(QCOW2_PARA::L2_TABLE_SLICE_BYTES - 1)) >> 3;
 	u64 l2_entry;
 	int ret;
-	u64 host_offset;
 
 	qcow2_assert(l2->read_ref() > 0);
 	l2->check(state, __func__, __LINE__);

--- a/qcow2/qcow2_flush_meta.cpp
+++ b/qcow2/qcow2_flush_meta.cpp
@@ -128,7 +128,7 @@ void MetaFlushingState::__write_slices(Qcow2State &qs,
 		return;
 
 	while (it != v1.cend()) {
-		int ret, tag;
+		int tag;
 		struct ublk_io_tgt *io;
 		Qcow2SliceMeta *m;
 
@@ -194,7 +194,7 @@ exit:
 void MetaFlushingState::__write_top(Qcow2State &qs,
 		struct ublksrv_queue *q)
 {
-	int ret, tag;
+	int tag;
 	struct ublk_io_tgt *io;
 
 	if (top.is_flushing(parent_blk_idx))
@@ -336,7 +336,7 @@ exit:
 void MetaFlushingState::__zero_my_cluster(Qcow2State &qs,
 		struct ublksrv_queue *q)
 {
-	int ret, tag;
+	int tag;
 	struct ublk_io_tgt *io;
 	Qcow2SliceMeta *m = slices_to_flush[0];
 	u64 cluster_off = m->get_offset() &

--- a/qcow2/qcow2_meta.cpp
+++ b/qcow2/qcow2_meta.cpp
@@ -789,7 +789,6 @@ exit:
 void Qcow2SliceMeta::wait_clusters(Qcow2State &qs,
 		const qcow2_io_ctx_t &ioc)
 {
-	unsigned cnt = 0;
 	for (int i = 0; i < get_nr_entries(); i++) {
 		u64 entry = get_entry(i);
 

--- a/qcow2/tgt_qcow2.cpp
+++ b/qcow2/tgt_qcow2.cpp
@@ -15,8 +15,6 @@ static int qcow2_init_tgt(struct ublksrv_dev *dev, int type, int argc, char
 		{ "file",		1,	NULL, 'f' },
 		{ NULL }
 	};
-	unsigned long long bytes;
-	struct stat st;
 	int jbuf_size;
 	char *jbuf;
 	int fd, opt, ret;
@@ -152,7 +150,6 @@ static int qcow2_recovery_tgt(struct ublksrv_dev *dev, int type)
 	const char *jbuf = dev->ctrl_dev->recovery_jbuf;
 	struct ublksrv_tgt_info *tgt = &dev->tgt;
 	int fd, ret;
-	long direct_io = 0;
 	char file[PATH_MAX];
 	struct ublk_params p;
 
@@ -422,7 +419,6 @@ queue_io:
 		}
 
 		if (ret > 0) {
-			u32 cqe_op;
 			u64 cluster_start = mapped_start &
 				~((1ULL << qs->header.cluster_bits) - 1);
 

--- a/tgt_loop.cpp
+++ b/tgt_loop.cpp
@@ -7,11 +7,6 @@
 #include "ublksrv_aio.h"
 #include "ublksrv_tgt.h"
 
-static const char *loop_tgt_backfile(struct ublksrv_tgt_info *tgt)
-{
-	return (const char *)tgt->tgt_data;
-}
-
 static bool backing_supports_discard(char *name)
 {
 	int fd;

--- a/tgt_null.cpp
+++ b/tgt_null.cpp
@@ -54,7 +54,7 @@ static int null_recovery_tgt(struct ublksrv_dev *dev, int type)
 	const struct ublksrv_ctrl_dev_info  *info = &dev->ctrl_dev->dev_info;
 	const char *jbuf = dev->ctrl_dev->recovery_jbuf;
 	struct ublksrv_tgt_info *tgt = &dev->tgt;
-	int fd, ret;
+	int ret;
 	struct ublk_params p;
 
 	ublk_assert(jbuf);

--- a/ublksrv_tgt.cpp
+++ b/ublksrv_tgt.cpp
@@ -267,7 +267,7 @@ static void ublksrv_io_handler(void *data)
 {
 	const struct ublksrv_ctrl_dev *ctrl_dev = (struct ublksrv_ctrl_dev *)data;
 	int dev_id = ctrl_dev->dev_info.dev_id;
-	int ret, i;
+	int i;
 	char buf[32];
 	struct ublksrv_dev *dev;
 	struct ublksrv_queue_info *info_array;
@@ -305,7 +305,6 @@ static void ublksrv_io_handler(void *data)
 	free(info_array);
 	free(jbuf);
 
-out_dev_deinit:
 	ublksrv_dev_deinit(dev);
 out:
 	syslog(LOG_INFO, "end ublksrv io daemon");
@@ -402,7 +401,6 @@ static int ublksrv_stop_io_daemon(const struct ublksrv_ctrl_dev *ctrl_dev)
 static int ublksrv_start_daemon(struct ublksrv_ctrl_dev *ctrl_dev)
 {
 	int cnt = 0, daemon_pid;
-	int ret;
 
 	if (ublksrv_ctrl_get_affinity(ctrl_dev) < 0)
 		return -1;
@@ -483,9 +481,7 @@ static int cmd_dev_add(int argc, char *argv[])
 	struct ublksrv_dev_data data = {0};
 	struct ublksrv_ctrl_dev *dev;
 	const struct ublksrv_tgt_type *tgt_type;
-	char *type = NULL;
-	int opt, ret, zcopy = 0;
-	int daemon_pid;
+	int opt, ret;
 	int uring_comp = 0;
 	int need_get_data = 0;
 	int user_recovery = 0;
@@ -690,7 +686,6 @@ static int cmd_dev_del(int argc, char *argv[])
 		{ "all",		0,	NULL, 'a' },
 		{ NULL }
 	};
-	struct ublksrv_ctrl_dev *dev;
 	int number = -1;
 	int opt, ret, i;
 
@@ -754,9 +749,8 @@ static int cmd_list_dev_info(int argc, char *argv[])
 		{ "verbose",		0,	NULL, 'v' },
 		{ NULL }
 	};
-	struct ublksrv_ctrl_dev *dev;
 	int number = -1;
-	int opt, ret, i;
+	int opt, i;
 	bool verbose = false;
 
 	while ((opt = getopt_long(argc, argv, "n:v",


### PR DESCRIPTION
This is largely in service of enabling more warnings in the code base.

Signed-off-by: reuben olinsky <reubeno.dev@gmail.com>