### PR TITLE
Enable more warnings on C++ code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,17 +18,17 @@ ublk_SOURCES = ublksrv_tgt.cpp tgt_null.cpp tgt_loop.cpp qcow2/tgt_qcow2.cpp \
 			   qcow2/qcow2.cpp qcow2/qcow2_meta.cpp qcow2/utils.cpp \
 			   qcow2/qcow2_flush_meta.cpp
 ublk_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-ublk_CPPFLAGS = -I$(top_srcdir)/include
+ublk_CPPFLAGS = $(ublk_CFLAGS) -I$(top_srcdir)/include
 ublk_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
 demo_null_SOURCES = demo_null.c
 demo_null_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-demo_null_CPPFLAGS = -I$(top_srcdir)/include
+demo_null_CPPFLAGS = $(demo_null_CFLAGS) -I$(top_srcdir)/include
 demo_null_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
 demo_event_SOURCES = demo_event.c
 demo_event_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-demo_event_CPPFLAGS = -I$(top_srcdir)/include
+demo_event_CPPFLAGS = $(demo_event_CFLAGS) -I$(top_srcdir)/include
 demo_event_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/build_with_liburing_src
+++ b/build_with_liburing_src
@@ -8,9 +8,10 @@
 autoreconf -i
 
 OPTS="-g -O0"
-LIBURING_DIR=/root/git/liburing	#replace with your own liburing path
+: "${LIBURING_DIR:=/root/git/liburing}"	#replace with your own liburing path
 PKG_CONFIG_PATH=${LIBURING_DIR} \
 ./configure \
+  --enable-gcc-warnings \
   CFLAGS="-I${LIBURING_DIR}/src/include $OPTS" \
   CXXFLAGS="-I${LIBURING_DIR}/src/include $OPTS" \
   LDFLAGS="-L${LIBURING_DIR}/src"

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,10 @@ if test "x$gcc_warnings" = "xyes"; then
     # Enable normal GCC warnings and a few more:
     #  - Warn about variable length arrays on stack.
     #  - Warn about large stack frames (since we may be used from threads).
-    WARNINGS_CFLAGS="-Wall -Werror"
+    #
+    # TODO: Address 'sign-compare' errors and remove -Wno-sign-compare
+    # TODO: Address 'parentheses' errors and remove -Wno-parentheses
+    WARNINGS_CFLAGS="-Wall -Werror -Wuninitialized -Wmaybe-uninitialized -Wno-sign-compare -Wno-parentheses"
     AC_C_COMPILE_FLAGS([WARNINGS_CFLAGS],
                        [-Wvla -Wframe-larger-than=5000 -Wstack-usage=10000],
                        [$CFLAGS -Werror])

--- a/qcow2/qcow2.cpp
+++ b/qcow2/qcow2.cpp
@@ -16,8 +16,9 @@ Qcow2Image:: ~Qcow2Image() {
 Qcow2State:: Qcow2State(const char *path, const struct ublksrv_dev *d):
 	min_bs_bits(9), dev(d), img(path), header(*this), l1_table(*this),
 	refcount_table(*this), cluster_allocator(*this),
+	cluster_map(*this),
 	meta_io_map(d->ctrl_dev->dev_info.nr_hw_queues),
-	cluster_map(*this), meta_flushing(*this)
+	meta_flushing(*this)
 {
 	u64 l1_bytes = get_l1_table_max_size();
 	u64 ref_table_bytes = get_refcount_table_act_size();
@@ -230,10 +231,12 @@ Qcow2State *make_qcow2state(const char *file, struct ublksrv_dev *dev)
 
 template <class T>
 slice_cache<T>::slice_cache(u8 slice_bits, u8 cluster_bits, u8 slice_virt_bits,
-		u32 max_size): slices(max_size >> slice_bits), evicted_slices({}),
+		u32 max_size):
 	slice_size_bits(slice_bits),
 	cluster_size_bits(cluster_bits),
-	slice_virt_size_bits(slice_virt_bits)
+	slice_virt_size_bits(slice_virt_bits),
+	slices(max_size >> slice_bits),
+	evicted_slices({})
 {
 }
 

--- a/qcow2/qcow2.h
+++ b/qcow2/qcow2.h
@@ -180,7 +180,7 @@ private:
 
 	friend class Qcow2State;
 
-	u32 l2_entries_order, cluster_bits;
+	u32 cluster_bits, l2_entries_order;
 
 	//l1/l2 entry alloc state
 	//

--- a/qcow2/qcow2_flush_meta.cpp
+++ b/qcow2/qcow2_flush_meta.cpp
@@ -2,7 +2,7 @@
 #include "qcow2.h"
 
 MetaFlushingState::MetaFlushingState(Qcow2TopTable &t, bool is_mapping):
-	top(t), mapping(is_mapping)
+	mapping(is_mapping), top(t)
 {
 	state = qcow2_meta_flush::IDLE;
 	slice_dirtied = 0;
@@ -526,11 +526,13 @@ int MetaFlushingState::calc_refcount_dirty_blk_range(Qcow2State& qs,
 	return 0;
 }
 
-Qcow2MetaFlushing::Qcow2MetaFlushing(Qcow2State &qs): state(qs),
-	tags(QCOW2_PARA::META_MAX_TAGS), mapping_stat(qs.l1_table, true),
-	refcount_stat(qs.refcount_table, false),
+Qcow2MetaFlushing::Qcow2MetaFlushing(Qcow2State &qs):
+	tags(QCOW2_PARA::META_MAX_TAGS),
 	refcnt_blk_start(-1),
-	refcnt_blk_end(-1)
+	refcnt_blk_end(-1),
+	state(qs),
+	mapping_stat(qs.l1_table, true),
+	refcount_stat(qs.refcount_table, false)
 {
 	for (int i = 0; i < tags.size(); i++)
 		tags[i] = true;

--- a/qcow2/qcow2_meta.cpp
+++ b/qcow2/qcow2_meta.cpp
@@ -9,7 +9,7 @@
 // side, another is for free side. This way guarantees that the returned slice
 // from alloc_slice is always valid
 Qcow2Meta::Qcow2Meta(Qcow2Header &h, u64 off, u32 sz, const char *name, u32 f):
-	offset(off), buf_sz(sz), header(h), flags(f), refcnt(2)
+	header(h), offset(off), buf_sz(sz), flags(f), refcnt(2)
 {
 	//used for implementing slice's ->reset() only
 	if (f & QCOW2_META_DONT_ALLOC_BUF)

--- a/ublksrv_tgt.cpp
+++ b/ublksrv_tgt.cpp
@@ -425,6 +425,9 @@ static int ublksrv_start_daemon(struct ublksrv_ctrl_dev *ctrl_dev)
 	return daemon_pid;
 }
 
+//todo: resolve stack usage warning for mkpath/__mkpath
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstack-usage="
 static int __mkpath(char *dir, mode_t mode)
 {
 	struct stat sb;
@@ -444,6 +447,7 @@ static int mkpath(const char *dir)
 {
 	return __mkpath(strdupa(dir), 0700);
 }
+#pragma GCC diagnostic pop
 
 static void ublksrv_tgt_set_params(struct ublksrv_ctrl_dev *cdev,
 		const char *jbuf)


### PR DESCRIPTION
This adds additional warnings when configuring with --enable-gcc-warnings.

A few warning types were specifically disabled with TODOs; they would be best to address in separate
changes.

Signed-off-by: reuben olinsky <reubeno.dev@gmail.com>