### PR TITLE
Simplify C++ coroutine usage

### DIFF
--- a/qcow2/qcow2_flush_meta.cpp
+++ b/qcow2/qcow2_flush_meta.cpp
@@ -66,7 +66,7 @@ again:
 	}
 
 	if (wait) {
-		co_io_job_submit_and_wait(tag);
+		co_await__suspend_always(tag);
 		goto again;
 	}
 
@@ -81,7 +81,7 @@ again:
 		bool done = false;
 		int io_ret = 0;
 
-		co_io_job_submit_and_wait(tag);
+		co_await__suspend_always(tag);
 
 		cqe = io->tgt_io_cqe;
 		done = (cqe && cqe->res != -EAGAIN);
@@ -162,7 +162,7 @@ again:
 	}
 
 	if (wait) {
-		co_io_job_submit_and_wait(tag);
+		co_await__suspend_always(tag);
 		goto again;
 	}
 
@@ -175,7 +175,7 @@ again:
 	if (ret > 0) {
 		const struct io_uring_cqe *cqe;
 
-		co_io_job_submit_and_wait(tag);
+		co_await__suspend_always(tag);
 
 		cqe = io->tgt_io_cqe;
 		ret = qcow2_meta_io_done(q, cqe);
@@ -296,7 +296,7 @@ again:
 	}
 
 	if (wait) {
-		co_io_job_submit_and_wait(tag);
+		co_await__suspend_always(tag);
 		goto again;
 	}
 
@@ -309,7 +309,7 @@ again:
 	if (ret > 0) {
 		const struct io_uring_cqe *cqe;
 
-		co_io_job_submit_and_wait(tag);
+		co_await__suspend_always(tag);
 
 		cqe = io->tgt_io_cqe;
 		ret = qcow2_meta_io_done(q, cqe);

--- a/qcow2/tgt_qcow2.cpp
+++ b/qcow2/tgt_qcow2.cpp
@@ -367,7 +367,7 @@ again:
 	}
 
 	if (wait) {
-		co_io_job_submit_and_wait(tag);
+		co_await__suspend_always(tag);
 
 		cqe = io->tgt_io_cqe;
 		io->tgt_io_cqe = NULL;
@@ -416,7 +416,7 @@ queue_io:
 		}
 
 		if (wait) {
-			co_io_job_submit_and_wait(tag);
+			co_await__suspend_always(tag);
 			goto queue_io;
 		}
 
@@ -424,7 +424,7 @@ queue_io:
 			u64 cluster_start = mapped_start &
 				~((1ULL << qs->header.cluster_bits) - 1);
 
-			co_io_job_submit_and_wait(tag);
+			co_await__suspend_always(tag);
 			cqe = io->tgt_io_cqe;
 			ret = cqe->res;
 			if (ret == -EAGAIN) {

--- a/tgt_loop.cpp
+++ b/tgt_loop.cpp
@@ -322,7 +322,7 @@ static co_io_job __loop_handle_io_async(const struct ublksrv_queue *q,
 					io->queued_tgt_io);
 		io->queued_tgt_io += 1;
 
-		co_io_job_submit_and_wait(tag);
+		co_await__suspend_always(tag);
 		io->queued_tgt_io -= 1;
 
 		if (io->tgt_io_cqe->res == -EAGAIN)

--- a/tgt_null.cpp
+++ b/tgt_null.cpp
@@ -85,7 +85,7 @@ static co_io_job __null_handle_io_async(const struct ublksrv_queue *q,
 {
 	ublksrv_complete_io(q, tag, data->iod->nr_sectors << 9);
 
-	co_io_job_return();
+	co_return;
 }
 
 static int null_handle_io_async(const struct ublksrv_queue *q,


### PR DESCRIPTION
Use more standard coroutine constructs to make the code shorter & easier to follow.

I'm not a coro expert, but maybe some of this was necessary with older compilers. However, looking at RedHat:
 - Fedora 36 is the earliest release that has kernel 6.0
 - The same Fedora has gcc 12.2.1, which compiles this simpler code just fine

Test Plan:
```
make
./tests/run_test.sh all 10 tests/tmp/
```