### PR TITLE
Fix gcc -O3 buffer size warning

### DIFF
--- a/ublksrv_tgt.cpp
+++ b/ublksrv_tgt.cpp
@@ -1003,7 +1003,7 @@ int main(int argc, char *argv[])
 	char exe[PATH_MAX];
 
 	full_cmd = argv[0];
-	strncpy(exe, full_cmd, PATH_MAX);
+	strncpy(exe, full_cmd, PATH_MAX - 1);
 
 	setvbuf(stdout, NULL, _IOLBF, 0);
 


### PR DESCRIPTION
There is no actual buffer overrun here, since `PATH_MAX` includes a null character (per @ming1 below). However, `gcc -O3` issues a warning when "size of buffer" == "size of `strncmp`" which becomes fatal since `build_with_liburing_src` specifies `-Wall`.

So, let just fix this to be "pedantically correct", and not simply "actually correct" :)
