### PR TITLE
missing <limits.h> header

### DIFF
--- a/include/ublksrv_tgt.h
+++ b/include/ublksrv_tgt.h
@@ -9,6 +9,7 @@
 #include <getopt.h>
 #include <string.h>
 #include <stdarg.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
building on my Debian 11 system with gcc I get these errors:

```
  CXX      ublk-tgt_loop.o
tgt_loop.cpp: In function ‘int loop_init_tgt(ublksrv_dev*, int, int, char**)’:
tgt_loop.cpp:123:27: error: ‘UINT_MAX’ was not declared in this scope
  123 |    .max_discard_sectors = UINT_MAX >> 9,
      |                           ^~~~~~~~
tgt_loop.cpp:8:1: note: ‘UINT_MAX’ is defined in header ‘<climits>’; did you forget to ‘#include <climits>’?
    7 | #include "ublksrv_tgt.h"
  +++ |+#include <climits>
    8 | 
```