### PR TITLE
tests/generic: fix invalid shebang

### DIFF
--- a/tests/generic/004
+++ b/tests/generic/004
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/generic/005
+++ b/tests/generic/005
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 . common/loop_common

--- a/tests/generic/006
+++ b/tests/generic/006
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT or GPL-2.0-only
 #!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
 
 . common/fio_common
 


### PR DESCRIPTION
Hello! I am playing around with ublk, tried to run some tests - found that some tests fails in my environment (ubuntu 22.04 + custom 6.1 kernel). This commit fixes this small issue. There are other tests in generic, where pluck order is correct, so it may be some stray mistype.

------------------------------------------------------

License identifier messed up script interpreter selection. Thus some tests failed to run.

This commit fixes shebang/license pluck order, so affected tests may run.