### PR TITLE
ublksrv_tgt: Add run_dir in __cmd_dev_del

### DIFF
--- a/ublksrv_tgt.cpp
+++ b/ublksrv_tgt.cpp
@@ -884,6 +884,7 @@ static int __cmd_dev_del(int number, bool log)
 	int ret;
 	struct ublksrv_dev_data data = {
 		.dev_id = number,
+		.run_dir = UBLKSRV_PID_DIR,
 	};
 
 	dev = ublksrv_ctrl_init(&data);


### PR DESCRIPTION
In __cmd_dev_del, when the struct data is specified, the initializer .run_dir is missing. This
has as a result, the ublksrv_stop_io_daemon function not to work correctly. Basically the subsequent
call to ublksrv_get_io_daemon_pid returns with
-EINVAL (-22).