### PR TITLE
DRAFT: Add io_uring register-buf based zero copy

### DIFF
--- a/include/ublk_cmd.h
+++ b/include/ublk_cmd.h
@@ -94,6 +94,11 @@
 	_IOWR('u', UBLK_IO_COMMIT_AND_FETCH_REQ, struct ublksrv_io_cmd)
 #define	UBLK_U_IO_NEED_GET_DATA		\
 	_IOWR('u', UBLK_IO_NEED_GET_DATA, struct ublksrv_io_cmd)
+#define UBLK_U_IO_REGISTER_IO_BUF   	\
+	_IOWR('u', 0x23, struct ublksrv_io_cmd)
+#define UBLK_U_IO_UNREGISTER_IO_BUF 	\
+	_IOWR('u', 0x24, struct ublksrv_io_cmd)
+
 
 /* only ABORT means that no re-fetch */
 #define UBLK_IO_RES_OK			0
@@ -395,6 +400,11 @@ struct ublk_param_zoned {
 	__u8	reserved[20];
 };
 
+struct ublk_param_dma_align {
+	__u32	alignment;
+	__u8	pad[4];
+};
+
 struct ublk_params {
 	/*
 	 * Total length of parameters, userspace has to set 'len' for both
@@ -407,12 +417,14 @@ struct ublk_params {
 #define UBLK_PARAM_TYPE_DISCARD         (1 << 1)
 #define UBLK_PARAM_TYPE_DEVT            (1 << 2)
 #define UBLK_PARAM_TYPE_ZONED           (1 << 3)
+#define UBLK_PARAM_TYPE_DMA_ALIGN       (1 << 4)
 	__u32	types;			/* types of parameter included */
 
 	struct ublk_param_basic		basic;
 	struct ublk_param_discard	discard;
 	struct ublk_param_devt		devt;
 	struct ublk_param_zoned	zoned;
+	struct ublk_param_dma_align	dma;
 };
 
 #endif

--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -87,6 +87,7 @@ struct ublk_io_data {
 #define UBLKSRV_QUEUE_IDLE	(1U << 1)
 #define UBLKSRV_QUEUE_IOCTL_OP	(1U << 2)
 #define UBLKSRV_USER_COPY	(1U << 3)
+#define UBLKSRV_ZERO_COPY       (1U << 4)
 
 /**
  * ublksrv_queue is 1:1 mapping with ublk driver's blk-mq queue, and

--- a/include/ublksrv_priv.h
+++ b/include/ublksrv_priv.h
@@ -191,6 +191,15 @@ static inline void ublksrv_mark_io_done(struct ublk_io *io, int res)
 	io->result = res;
 }
 
+static inline struct io_uring_sqe *ublksrv_alloc_sqe(struct io_uring *r)
+{
+	unsigned left = io_uring_sq_space_left(r);
+
+	if (left < 1)
+		io_uring_submit(r);
+	return io_uring_get_sqe(r);
+}
+
 int create_pid_file(const char *pid_file, int *pid_fd);
 
 extern void ublksrv_build_cpu_str(char *buf, int len, const cpu_set_t *cpuset);

--- a/include/ublksrv_priv.h
+++ b/include/ublksrv_priv.h
@@ -191,11 +191,6 @@ static inline void ublksrv_mark_io_done(struct ublk_io *io, int res)
 	io->result = res;
 }
 
-static inline bool ublksrv_io_done(struct ublk_io *io)
-{
-	return io->flags & UBLKSRV_IO_FREE;
-}
-
 int create_pid_file(const char *pid_file, int *pid_fd);
 
 extern void ublksrv_build_cpu_str(char *buf, int len, const cpu_set_t *cpuset);

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -152,7 +152,7 @@ static inline int ublksrv_queue_io_cmd(struct _ublksrv_queue *q,
 	else if (io->flags & UBLKSRV_NEED_FETCH_RQ)
 		cmd_op = UBLK_IO_FETCH_REQ;
 
-	sqe = io_uring_get_sqe(&q->ring);
+	sqe = ublksrv_alloc_sqe(&q->ring);
 	if (!sqe) {
 		ublk_err("%s: run out of sqe %d, tag %d\n",
 				__func__, q->q_id, tag);

--- a/lib/ublksrv_cmd.c
+++ b/lib/ublksrv_cmd.c
@@ -109,7 +109,7 @@ static int __ublksrv_ctrl_cmd(struct ublksrv_ctrl_dev *dev,
 	struct io_uring_cqe *cqe;
 	int ret = -EINVAL;
 
-	sqe = io_uring_get_sqe(&dev->ring);
+	sqe = ublksrv_alloc_sqe(&dev->ring);
 	if (!sqe) {
 		fprintf(stderr, "can't get sqe ret %d\n", ret);
 		return ret;

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -171,14 +171,15 @@ static inline void ublk_get_sqe_pair(struct io_uring *r,
 		*sqe2 = io_uring_get_sqe(r);
 }
 
-static inline enum io_uring_op ublk_to_uring_fs_op(const struct ublksrv_io_desc *iod)
+static inline enum io_uring_op ublk_to_uring_fs_op(
+		const struct ublksrv_io_desc *iod, bool zc)
 {
 	unsigned ublk_op = ublksrv_get_op(iod);
 
 	if (ublk_op == UBLK_IO_OP_READ)
-		return IORING_OP_READ;
+		return zc ? IORING_OP_READ_FIXED : IORING_OP_READ;
 	else if (ublk_op == UBLK_IO_OP_WRITE)
-		return IORING_OP_WRITE;
+		return zc ? IORING_OP_WRITE_FIXED : IORING_OP_WRITE;
 	assert(0);
 }
 

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -166,6 +166,17 @@ static inline void ublk_get_sqe_pair(struct io_uring *r,
 		*sqe2 = io_uring_get_sqe(r);
 }
 
+static inline enum io_uring_op ublk_to_uring_fs_op(const struct ublksrv_io_desc *iod)
+{
+	unsigned ublk_op = ublksrv_get_op(iod);
+
+	if (ublk_op == UBLK_IO_OP_READ)
+		return IORING_OP_READ;
+	else if (ublk_op == UBLK_IO_OP_WRITE)
+		return IORING_OP_WRITE;
+	assert(0);
+}
+
 int ublksrv_tgt_send_dev_event(int evtfd, int dev_id);
 
 struct ublksrv_queue_info {

--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -282,4 +282,67 @@ static inline void ublksrv_tgt_io_done(const struct ublksrv_queue *q,
 	io->co.resume();
 }
 
+static inline void ublk_queue_alloc_sqe3(const struct ublksrv_queue *q,
+		struct io_uring_sqe **sqe1, struct io_uring_sqe **sqe2,
+		struct io_uring_sqe **sqe3)
+{
+	struct io_uring *r = q->ring_ptr;
+	unsigned left = io_uring_sq_space_left(r);
+
+	if (left < 3)
+		io_uring_submit(r);
+
+	*sqe1 = io_uring_get_sqe(r);
+	*sqe2 = io_uring_get_sqe(r);
+	*sqe3 = io_uring_get_sqe(r);
+}
+
+static inline void __set_sqe_cmd_op(struct io_uring_sqe *sqe, __u32 cmd_op)
+{
+	__u32 *addr = (__u32 *)&sqe->off;
+
+	addr[0] = cmd_op;
+	addr[1] = 0;
+}
+
+static inline struct ublksrv_io_cmd *__get_sqe_cmd(struct io_uring_sqe *sqe)
+{
+	return (struct ublksrv_io_cmd *)&sqe->addr3;
+}
+
+static inline void io_uring_prep_buf_register(struct io_uring_sqe *sqe,
+		int dev_fd, int tag, int q_id, __u64 index)
+{
+	struct ublksrv_io_cmd *cmd = __get_sqe_cmd(sqe);
+
+	io_uring_prep_read(sqe, dev_fd, 0, 0, 0);
+	sqe->opcode		= IORING_OP_URING_CMD;
+	sqe->flags		|= IOSQE_FIXED_FILE;
+	__set_sqe_cmd_op(sqe, UBLK_U_IO_REGISTER_IO_BUF);
+
+	cmd->tag		= tag;
+	cmd->addr		= index;
+	cmd->q_id		= q_id;
+}
+
+static inline void io_uring_prep_buf_unregister(struct io_uring_sqe *sqe,
+		int dev_fd, int tag, int q_id, __u64 index)
+{
+	struct ublksrv_io_cmd *cmd = __get_sqe_cmd(sqe);
+
+	io_uring_prep_read(sqe, dev_fd, 0, 0, 0);
+	sqe->opcode		= IORING_OP_URING_CMD;
+	sqe->flags		|= IOSQE_FIXED_FILE;
+	__set_sqe_cmd_op(sqe, UBLK_U_IO_UNREGISTER_IO_BUF);
+
+	cmd->tag		= tag;
+	cmd->addr		= index;
+	cmd->q_id		= q_id;
+}
+
+static inline bool ublksrv_tgt_queue_zc(const struct ublksrv_queue *q)
+{
+	return ublksrv_queue_state(q) & UBLKSRV_ZERO_COPY;
+}
+
 #endif

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -857,6 +857,8 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 
 	ublksrv_dev_set_cq_depth(dev, 2 * tgt->tgt_ring_depth);
 
+	if (info->flags & UBLK_F_SUPPORT_ZERO_COPY)
+		return -EINVAL;
 	return 0;
 }
 

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -279,18 +279,18 @@ static inline int loop_fallocate_mode(const struct ublksrv_io_desc *iod)
        return mode;
 }
 
-static void loop_queue_tgt_read(const struct ublksrv_queue *q,
+static void lo_rw_user_copy(const struct ublksrv_queue *q,
 		const struct ublksrv_io_desc *iod, int tag)
 {
 	unsigned ublk_op = ublksrv_get_op(iod);
 	const struct loop_tgt_data *tgt_data = (struct loop_tgt_data*) q->dev->tgt.tgt_data;
+	struct io_uring_sqe *sqe, *sqe2;
+	__u64 pos = ublk_pos(q->q_id, tag, 0);
+	void *buf = ublksrv_queue_get_io_buf(q, tag);
 
-	if (tgt_data->user_copy) {
-		struct io_uring_sqe *sqe, *sqe2;
-		__u64 pos = ublk_pos(q->q_id, tag, 0);
-		void *buf = ublksrv_queue_get_io_buf(q, tag);
-
-		ublk_get_sqe_pair(q->ring_ptr, &sqe, &sqe2);
+	ublk_get_sqe_pair(q->ring_ptr, &sqe, &sqe2);
+	if (ublk_op == UBLK_IO_OP_READ) {
+		/* read from backing file to io buffer */
 		io_uring_prep_read(sqe, 1 /*fds[1]*/,
 				buf,
 				iod->nr_sectors << 9,
@@ -298,11 +298,38 @@ static void loop_queue_tgt_read(const struct ublksrv_queue *q,
 		io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE | IOSQE_IO_LINK);
 		sqe->user_data = build_user_data(tag, ublk_op, 1, 1);
 
+		/* copy io buffer to ublkc device */
 		io_uring_prep_write(sqe2, 0 /*fds[0]*/,
 				buf, iod->nr_sectors << 9, pos);
 		io_uring_sqe_set_flags(sqe2, IOSQE_FIXED_FILE);
 		/* bit63 marks us as tgt io */
 		sqe2->user_data = build_user_data(tag, ublk_op, 0, 1);
+	} else {
+		/* copy ublkc device data to io buffer */
+		io_uring_prep_read(sqe, 0 /*fds[0]*/,
+			buf, iod->nr_sectors << 9, pos);
+		io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE | IOSQE_IO_LINK);
+		sqe->user_data = build_user_data(tag, ublk_op, 1, 1);
+
+		/* write data in io buffer to backing file */
+		io_uring_prep_write(sqe2, 1 /*fds[1]*/,
+			buf, iod->nr_sectors << 9,
+			(iod->start_sector + tgt_data->offset) << 9);
+		io_uring_sqe_set_flags(sqe2, IOSQE_FIXED_FILE);
+		sqe2->rw_flags |= RWF_DSYNC;
+		/* bit63 marks us as tgt io */
+		sqe2->user_data = build_user_data(tag, ublk_op, 0, 1);
+	}
+}
+
+static void loop_queue_tgt_read(const struct ublksrv_queue *q,
+		const struct ublksrv_io_desc *iod, int tag)
+{
+	unsigned ublk_op = ublksrv_get_op(iod);
+	const struct loop_tgt_data *tgt_data = (struct loop_tgt_data*) q->dev->tgt.tgt_data;
+
+	if (tgt_data->user_copy) {
+		lo_rw_user_copy(q, iod, tag);
 	} else {
 		struct io_uring_sqe *sqe;
 		void *buf = (void *)iod->addr;
@@ -324,23 +351,7 @@ static void loop_queue_tgt_write(const struct ublksrv_queue *q,
 	const struct loop_tgt_data *tgt_data = (struct loop_tgt_data*) q->dev->tgt.tgt_data;
 
 	if (tgt_data->user_copy) {
-		struct io_uring_sqe *sqe, *sqe2;
-		__u64 pos = ublk_pos(q->q_id, tag, 0);
-		void *buf = ublksrv_queue_get_io_buf(q, tag);
-
-		ublk_get_sqe_pair(q->ring_ptr, &sqe, &sqe2);
-		io_uring_prep_read(sqe, 0 /*fds[0]*/,
-			buf, iod->nr_sectors << 9, pos);
-		io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE | IOSQE_IO_LINK);
-		sqe->user_data = build_user_data(tag, ublk_op, 1, 1);
-
-		io_uring_prep_write(sqe2, 1 /*fds[1]*/,
-			buf, iod->nr_sectors << 9,
-			(iod->start_sector + tgt_data->offset) << 9);
-		io_uring_sqe_set_flags(sqe2, IOSQE_FIXED_FILE);
-		sqe2->rw_flags |= RWF_DSYNC;
-		/* bit63 marks us as tgt io */
-		sqe2->user_data = build_user_data(tag, ublk_op, 0, 1);
+		lo_rw_user_copy(q, iod, tag);
 	} else {
 		struct io_uring_sqe *sqe;
 		void *buf = (void *)iod->addr;

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -280,10 +280,10 @@ static inline int loop_fallocate_mode(const struct ublksrv_io_desc *iod)
 }
 
 static void lo_rw_user_copy(const struct ublksrv_queue *q,
-		const struct ublksrv_io_desc *iod, int tag)
+		const struct ublksrv_io_desc *iod, int tag,
+		const struct loop_tgt_data *tgt_data)
 {
 	unsigned ublk_op = ublksrv_get_op(iod);
-	const struct loop_tgt_data *tgt_data = (struct loop_tgt_data*) q->dev->tgt.tgt_data;
 	struct io_uring_sqe *sqe, *sqe2;
 	__u64 pos = ublk_pos(q->q_id, tag, 0);
 	void *buf = ublksrv_queue_get_io_buf(q, tag);
@@ -322,50 +322,36 @@ static void lo_rw_user_copy(const struct ublksrv_queue *q,
 	}
 }
 
-static void loop_queue_tgt_read(const struct ublksrv_queue *q,
-		const struct ublksrv_io_desc *iod, int tag)
+static void lo_rw(const struct ublksrv_queue *q,
+		const struct ublksrv_io_desc *iod, int tag,
+		const struct loop_tgt_data *tgt_data)
 {
-	unsigned ublk_op = ublksrv_get_op(iod);
-	const struct loop_tgt_data *tgt_data = (struct loop_tgt_data*) q->dev->tgt.tgt_data;
+	enum io_uring_op uring_op = ublk_to_uring_fs_op(iod);
+	void *buf = (void *)iod->addr;
+	struct io_uring_sqe *sqe;
 
-	if (tgt_data->user_copy) {
-		lo_rw_user_copy(q, iod, tag);
-	} else {
-		struct io_uring_sqe *sqe;
-		void *buf = (void *)iod->addr;
-
-		ublk_get_sqe_pair(q->ring_ptr, &sqe, NULL);
-		io_uring_prep_read(sqe, 1 /*fds[1]*/,
-			buf,
-			iod->nr_sectors << 9,
-			(iod->start_sector + tgt_data->offset) << 9);
-		io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
-		sqe->user_data = build_user_data(tag, ublk_op, 0, 1);
-	}
+	ublk_get_sqe_pair(q->ring_ptr, &sqe, NULL);
+	io_uring_prep_rw(uring_op,
+		sqe,
+		1 /*fds[1]*/,
+		buf,
+		iod->nr_sectors << 9,
+		(iod->start_sector + tgt_data->offset) << 9);
+	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+	if (uring_op == IORING_OP_WRITE)
+		sqe->rw_flags |= RWF_DSYNC;
+	sqe->user_data = build_user_data(tag, ublksrv_get_op(iod), 0, 1);
 }
 
-static void loop_queue_tgt_write(const struct ublksrv_queue *q,
+static void loop_queue_tgt_rw(const struct ublksrv_queue *q,
 		const struct ublksrv_io_desc *iod, int tag)
 {
-	unsigned ublk_op = ublksrv_get_op(iod);
 	const struct loop_tgt_data *tgt_data = (struct loop_tgt_data*) q->dev->tgt.tgt_data;
 
-	if (tgt_data->user_copy) {
-		lo_rw_user_copy(q, iod, tag);
-	} else {
-		struct io_uring_sqe *sqe;
-		void *buf = (void *)iod->addr;
-
-		ublk_get_sqe_pair(q->ring_ptr, &sqe, NULL);
-		io_uring_prep_write(sqe, 1 /*fds[1]*/,
-			buf,
-			iod->nr_sectors << 9,
-			(iod->start_sector + tgt_data->offset) << 9);
-		io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
-		sqe->rw_flags |= RWF_DSYNC;
-		/* bit63 marks us as tgt io */
-		sqe->user_data = build_user_data(tag, ublk_op, 0, 1);
-	}
+	if (tgt_data->user_copy)
+		lo_rw_user_copy(q, iod, tag, tgt_data);
+	else
+		lo_rw(q, iod, tag, tgt_data);
 }
 
 static int loop_queue_tgt_io(const struct ublksrv_queue *q,
@@ -399,10 +385,8 @@ static int loop_queue_tgt_io(const struct ublksrv_queue *q,
 		sqe->user_data = build_user_data(tag, ublk_op, 0, 1);
 		break;
 	case UBLK_IO_OP_READ:
-		loop_queue_tgt_read(q, iod, tag);
-		break;
 	case UBLK_IO_OP_WRITE:
-		loop_queue_tgt_write(q, iod, tag);
+		loop_queue_tgt_rw(q, iod, tag);
 		break;
 	default:
 		return -EINVAL;

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -404,16 +404,10 @@ static co_io_job __loop_handle_io_async(const struct ublksrv_queue *q,
 	int ret;
 	struct ublk_io_tgt *io = __ublk_get_io_tgt_data(data);
 
-	io->queued_tgt_io = 0;
  again:
 	ret = loop_queue_tgt_io(q, data, tag);
 	if (ret > 0) {
-		if (io->queued_tgt_io)
-			ublk_err("bad queued_tgt_io %d\n", io->queued_tgt_io);
-		io->queued_tgt_io += 1;
-
 		co_await__suspend_always(tag);
-		io->queued_tgt_io -= 1;
 
 		if (io->tgt_io_cqe->res == -EAGAIN)
 			goto again;
@@ -459,11 +453,6 @@ static void loop_tgt_io_done(const struct ublksrv_queue *q,
 		return;
 
 	ublk_assert(tag == data->tag);
-	if (!io->queued_tgt_io)
-		ublk_err("%s: wrong queued_tgt_io: res %d qid %u tag %u, cmd_op %u\n",
-			__func__, cqe->res, q->q_id,
-			user_data_to_tag(cqe->user_data),
-			user_data_to_op(cqe->user_data));
 	io->tgt_io_cqe = cqe;
 	io->co.resume();
 }

--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -109,6 +109,8 @@ static int loop_setup_tgt(struct ublksrv_dev *dev, int type, bool recovery,
 	if (tgt_data->user_copy)
 		tgt->tgt_ring_depth *= 2;
 
+	if (info->flags & UBLK_F_SUPPORT_ZERO_COPY)
+		return -EINVAL;
 
 	return 0;
 }

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -4,6 +4,14 @@
 
 #include "ublksrv_tgt.h"
 
+#ifndef IORING_NOP_INJECT_RESULT
+#define IORING_NOP_INJECT_RESULT        (1U << 0)
+#endif
+
+#ifndef IORING_NOP_FIXED_BUFFER
+#define IORING_NOP_FIXED_BUFFER         (1U << 3)
+#endif
+
 static int null_recover_tgt(struct ublksrv_dev *dev, int type);
 
 static int null_setup_tgt(struct ublksrv_dev *dev)
@@ -29,6 +37,8 @@ static int null_setup_tgt(struct ublksrv_dev *dev)
 
 	tgt->dev_size = p.basic.dev_sectors << 9;
 	tgt->tgt_ring_depth = info->queue_depth;
+	if (info->flags & UBLK_F_SUPPORT_ZERO_COPY)
+		tgt->tgt_ring_depth *= 2;
 	tgt->nr_fds = 0;
 	ublksrv_tgt_set_io_data_size(tgt);
 
@@ -75,11 +85,56 @@ static int null_recover_tgt(struct ublksrv_dev *dev, int type)
 	return null_setup_tgt(dev);
 }
 
+static int null_submit_io(const struct ublksrv_queue *q,
+		const struct ublk_io_data *data, int tag)
+{
+	unsigned ublk_op = ublksrv_get_op(data->iod);
+	struct io_uring_sqe *reg;
+	struct io_uring_sqe *rw;
+	struct io_uring_sqe *ureg;
+
+	if (!ublksrv_tgt_queue_zc(q))
+		return 0;
+
+	ublk_queue_alloc_sqe3(q, &reg, &rw, &ureg);
+
+	io_uring_prep_buf_register(reg, 0, tag, q->q_id, tag);
+	reg->user_data = build_user_data(tag, 0xfe, UBLK_IO_TGT_BUF, 1);
+	reg->flags |= IOSQE_CQE_SKIP_SUCCESS | IOSQE_IO_LINK;
+
+	io_uring_prep_nop(rw);
+	rw->buf_index = tag;
+	rw->flags |= IOSQE_FIXED_FILE | IOSQE_IO_LINK;
+	rw->rw_flags = IORING_NOP_FIXED_BUFFER | IORING_NOP_INJECT_RESULT;
+	rw->len = data->iod->nr_sectors << 9; 	/* injected result */
+	rw->user_data = build_user_data(tag, ublk_op, UBLK_IO_TGT_IO, 1);
+
+	io_uring_prep_buf_unregister(ureg, 0, tag, q->q_id, tag);
+	ureg->user_data = build_user_data(tag, 0xff, UBLK_IO_TGT_BUF, 1);
+
+	// buf register is marked as IOSQE_CQE_SKIP_SUCCESS
+	return 2;
+}
+
 static co_io_job __null_handle_io_async(const struct ublksrv_queue *q,
 		const struct ublk_io_data *data, int tag)
 {
-	ublksrv_complete_io(q, tag, data->iod->nr_sectors << 9);
+	struct ublk_io_tgt *io = __ublk_get_io_tgt_data(data);
+	int ret;
 
+again:
+	ret = null_submit_io(q, data, tag);
+	if (ret >= 0) {
+		int io_res = data->iod->nr_sectors << 9;
+		while (ret-- > 0) {
+			co_await__suspend_always(tag);
+			if (ublksrv_tgt_process_cqe(io, &io_res) == -EAGAIN)
+				goto again;
+		}
+		ublksrv_complete_io(q, tag, io_res);
+	} else {
+		ublk_err( "fail to queue io %d, ret %d\n", tag, ret);
+	}
 	co_return;
 }
 
@@ -93,6 +148,13 @@ static int null_handle_io_async(const struct ublksrv_queue *q,
 	return 0;
 }
 
+static void null_tgt_io_done(const struct ublksrv_queue *q,
+		const struct ublk_io_data *data,
+		const struct io_uring_cqe *cqe)
+{
+	ublksrv_tgt_io_done(q, data, cqe);
+}
+
 static void null_cmd_usage()
 {
 	const char *name = "null";
@@ -103,6 +165,7 @@ static void null_cmd_usage()
 
 static const struct ublksrv_tgt_type  null_tgt_type = {
 	.handle_io_async = null_handle_io_async,
+	.tgt_io_done = null_tgt_io_done,
 	.usage_for_add = null_cmd_usage,
 	.init_tgt = null_init_tgt,
 	.name	=  "null",

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -484,6 +484,7 @@ static int ublksrv_parse_add_opts(struct ublksrv_dev_data *data, int *efd, int a
 		{ "unprivileged",	0,	NULL, 0},
 		{ "usercopy",	0,	NULL, 0},
 		{ "eventfd",	1,	NULL, 0},
+		{ "zerocopy",	0,	NULL, 'z'},
 		{ NULL }
 	};
 
@@ -494,7 +495,7 @@ static int ublksrv_parse_add_opts(struct ublksrv_dev_data *data, int *efd, int a
 
 	mkpath(data->run_dir);
 
-	while ((opt = getopt_long(argc, argv, "-:t:n:d:q:u:g:r:e:i:",
+	while ((opt = getopt_long(argc, argv, "-:t:n:d:q:u:g:r:e:i:z",
 				  longopts, &option_index)) != -1) {
 		switch (opt) {
 		case 'n':
@@ -504,7 +505,7 @@ static int ublksrv_parse_add_opts(struct ublksrv_dev_data *data, int *efd, int a
 			data->tgt_type = optarg;
 			break;
 		case 'z':
-			data->flags |= UBLK_F_SUPPORT_ZERO_COPY;
+			data->flags |= UBLK_F_SUPPORT_ZERO_COPY | UBLK_F_USER_COPY;
 			break;
 		case 'q':
 			data->nr_hw_queues = strtol(optarg, NULL, 10);

--- a/tests/loop/009
+++ b/tests/loop/009
@@ -1,0 +1,12 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
+
+. common/fio_common
+. common/loop_common
+
+file=`_create_loop_image "data" $LO_IMG_SZ`
+export T_TYPE_PARAMS="-t loop -q 1 --buffered_io -f $file -z"
+
+__run_dev_perf 1
+
+_remove_loop_image $file

--- a/tests/loop/010
+++ b/tests/loop/010
@@ -1,0 +1,13 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
+
+. common/fio_common
+. common/loop_common
+
+echo "run loop zerocopy test"
+file=`_create_loop_image "data" $LO_IMG_SZ`
+export T_TYPE_PARAMS="-t loop -q 1 -f $file -z"
+
+__run_dev_perf 1
+
+_remove_loop_image $file

--- a/tests/null/007
+++ b/tests/null/007
@@ -1,0 +1,8 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
+
+. common/fio_common
+
+export T_TYPE_PARAMS="-t null -q 2 -z"
+
+__run_dev_perf 2


### PR DESCRIPTION

Linux kernel v6.15 will support buffer registered ublk zero copy, add this feature for null & loop target first.

So far, it needs linux kernel next tree for test.

https://web.git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/log/