### PR TITLE
Set write cache at default for both loop and null

### DIFF
--- a/targets/ublk.loop.cpp
+++ b/targets/ublk.loop.cpp
@@ -148,6 +148,7 @@ static int loop_init_tgt(struct ublksrv_dev *dev, int type, int argc, char
 	struct ublk_params p = {
 		.types = UBLK_PARAM_TYPE_BASIC | UBLK_PARAM_TYPE_DISCARD,
 		.basic = {
+			.attrs                  = UBLK_ATTR_VOLATILE_CACHE,
 			.logical_bs_shift	= 9,
 			.physical_bs_shift	= 12,
 			.io_opt_shift	= 12,
@@ -338,7 +339,6 @@ static void loop_queue_tgt_write(const struct ublksrv_queue *q,
 			buf, iod->nr_sectors << 9,
 			(iod->start_sector + tgt_data->offset) << 9);
 		io_uring_sqe_set_flags(sqe2, IOSQE_FIXED_FILE);
-		sqe2->rw_flags |= RWF_DSYNC;
 		/* bit63 marks us as tgt io */
 		sqe2->user_data = build_user_data(tag, ublk_op, 0, 1);
 	} else {
@@ -351,7 +351,6 @@ static void loop_queue_tgt_write(const struct ublksrv_queue *q,
 			iod->nr_sectors << 9,
 			(iod->start_sector + tgt_data->offset) << 9);
 		io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
-		sqe->rw_flags |= RWF_DSYNC;
 		/* bit63 marks us as tgt io */
 		sqe->user_data = build_user_data(tag, ublk_op, 0, 1);
 	}

--- a/targets/ublk.null.cpp
+++ b/targets/ublk.null.cpp
@@ -17,6 +17,7 @@ static int null_init_tgt(struct ublksrv_dev *dev, int type, int argc,
 	struct ublk_params p = {
 		.types = UBLK_PARAM_TYPE_BASIC,
 		.basic = {
+			.attrs                  = UBLK_ATTR_VOLATILE_CACHE,
 			.logical_bs_shift	= 9,
 			.physical_bs_shift	= 12,
 			.io_opt_shift		= 12,


### PR DESCRIPTION


nbd sets write cache according to negotiated flags.

For both loop and null, set write cache at default, since the two targets implements flush command handling.