### PR TITLE
Scan ublk devices more efficiently and remove MAX_NR_UBLK_DEVS

### DIFF
--- a/targets/include/ublksrv_tgt.h
+++ b/targets/include/ublksrv_tgt.h
@@ -35,8 +35,6 @@ static inline unsigned ilog2(unsigned x)
     return sizeof(unsigned) * 8 - 1 - __builtin_clz(x);
 }
 
-#define MAX_NR_UBLK_DEVS	128
-
 /*
  * Our convention is to use this macro instead of raw `co_await` to make it
  * easy to log `tag` when debugging coroutine issues.

--- a/targets/ublk.cpp
+++ b/targets/ublk.cpp
@@ -174,7 +174,7 @@ static int cmd_dev_del(int argc, char *argv[])
 		{ NULL }
 	};
 	int number = -1;
-	int opt, ret, i;
+	int opt, ret = 0;
 	unsigned async = 0;
 	int option_index = 0;
 
@@ -196,11 +196,10 @@ static int cmd_dev_del(int argc, char *argv[])
 	if (number >= 0)
 		return __cmd_dev_del(number, true, async);
 
-	for (i = 0; i < MAX_NR_UBLK_DEVS; i++) {
-		ret = __cmd_dev_del(i, false, async);
-		if (ret == -EOPNOTSUPP)
-			return ret;
-	}
+	for_each_dev([&](unsigned dev_id) {
+		if (ret != -EOPNOTSUPP)
+			ret = __cmd_dev_del(dev_id, false, async);
+	});
 
 	return ret;
 }
@@ -300,7 +299,7 @@ static int cmd_list_dev_info(int argc, char *argv[])
 		{ NULL }
 	};
 	int number = -1;
-	int opt, i;
+	int opt, ret = 0;
 	bool verbose = false;
 
 	while ((opt = getopt_long(argc, argv, "n:v",
@@ -318,12 +317,10 @@ static int cmd_list_dev_info(int argc, char *argv[])
 	if (number >= 0)
 		return list_one_dev(number, true, verbose);
 
-	for (i = 0; i < MAX_NR_UBLK_DEVS; i++) {
-		int ret = list_one_dev(i, false, verbose);
-
-		if (ret == -EOPNOTSUPP)
-			return ret;
-	}
+	for_each_dev([&](unsigned dev_id) {
+		if (ret != -EOPNOTSUPP)
+			ret = list_one_dev(dev_id, false, verbose);
+	});
 
 	return 0;
 }


### PR DESCRIPTION
The `ublk list` and `del` commands currently find the ublk devices by
testing every `dev_id` up to 128. This misses any ublk devices with larger
`dev_id` values, and is wasteful if most of the `dev_id` values are unused.
Iterate the `/sys/class/ublk-char` directory instead to efficiently find
all ublk `dev_id` values in use. Remove the now unused `MAX_NR_UBLK_DEVS`.