### PR TITLE
Always compile ublk_set_debug_mask and ublk_get_debug_mask

### DIFF
--- a/include/ublksrv_utils.h
+++ b/include/ublksrv_utils.h
@@ -60,14 +60,13 @@ extern void ublk_dbg(int level, const char *fmt, ...)
 	__attribute__ ((format (printf, 2, 3)));
 extern void ublk_ctrl_dbg(int level, const char *fmt, ...)
 	__attribute__ ((format (printf, 2, 3)));
-extern void ublk_set_debug_mask(unsigned mask);
-extern unsigned ublk_get_debug_mask(unsigned mask);
 #else
 static inline void ublk_dbg(int level, const char *fmt, ...) { }
 static inline void ublk_ctrl_dbg(int level, const char *fmt, ...) { }
-static inline void ublk_set_debug_mask(unsigned mask) {}
-static inline unsigned ublk_get_debug_mask(unsigned mask) { return 0;}
 #endif
+
+extern void ublk_set_debug_mask(unsigned mask);
+extern unsigned ublk_get_debug_mask(unsigned mask);
 
 extern void ublk_log(const char *fmt, ...)
 	__attribute__ ((format (printf, 1, 2)));

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -99,6 +99,15 @@ unsigned ublk_get_debug_mask(unsigned mask)
 {
 	return ublk_debug_mask;
 }
+#else
+void ublk_set_debug_mask(unsigned mask)
+{
+}
+
+unsigned ublk_get_debug_mask(unsigned mask)
+{
+	return 0;
+}
 #endif
 
 cpu_set_t *ublk_make_cpuset(int num_sets, const char *cpuset)


### PR DESCRIPTION
Currently ublk_set_debug_mask and ublk_get_debug_mask are only compiled if --enable-debug is passed to configure, and are dummied out in ublksrv_utils.h if DEBUG is not set.

Unfortunately this doesn't work for other programs linking to ublksrv, as they non-intuitively need to define DEBUG themselves in order for these functions to be available in the header file.

Fix this by exporting ublk_set_debug_mask and ublk_get_debug_mask unconditionally, using dummy versions if not in debug mode.