### PR TITLE
Device identification of ublk devices

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,54 +37,54 @@ ublk_CPPFLAGS = $(ublk_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
 ublk_null_SOURCES = $(TGT_DIR)/ublk.null.cpp $(TGT_DIR)/ublksrv_tgt.cpp
-ublk_null_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-ublk_null_CPPFLAGS = $(ublk_null_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_null_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+ublk_null_CFLAGS = $(ublk_CFLAGS)
+ublk_null_CPPFLAGS = $(ublk_CPPFLAGS)
+ublk_null_LDADD = $(ublk_LDADD)
 
 ublk_iscsi_SOURCES = $(TGT_DIR)/ublk.iscsi.cpp $(TGT_DIR)/ublksrv_tgt.cpp
-ublk_iscsi_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-ublk_iscsi_CPPFLAGS = $(ublk_iscsi_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_iscsi_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS) -liscsi
+ublk_iscsi_CFLAGS = $(ublk_CFLAGS)
+ublk_iscsi_CPPFLAGS = $(ublk_CPPFLAGS)
+ublk_iscsi_LDADD = $(ublk_LDADD) -liscsi
 
 ublk_loop_SOURCES = $(TGT_DIR)/ublk.loop.cpp $(TGT_DIR)/ublksrv_tgt.cpp
-ublk_loop_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-ublk_loop_CPPFLAGS = $(ublk_loop_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_loop_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+ublk_loop_CFLAGS = $(ublk_CFLAGS)
+ublk_loop_CPPFLAGS = $(ublk_CPPFLAGS)
+ublk_loop_LDADD = $(ublk_LDADD)
 
 ublk_nbd_SOURCES = $(TGT_DIR)/nbd/ublk.nbd.cpp $(TGT_DIR)/nbd/cliserv.c $(TGT_DIR)/nbd/nbd-client.c $(TGT_DIR)/ublksrv_tgt.cpp
-ublk_nbd_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-ublk_nbd_CPPFLAGS = $(ublk_nbd_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_nbd_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+ublk_nbd_CFLAGS = $(ublk_CFLAGS)
+ublk_nbd_CPPFLAGS = $(ublk_CPPFLAGS)
+ublk_nbd_LDADD = $(ublk_LDADD)
 
 ublk_nvme_vfio_SOURCES = $(TGT_DIR)/nvme/ublk.nvme_vfio.cpp $(TGT_DIR)/dma_buf.c $(TGT_DIR)/ublksrv_tgt.cpp
-ublk_nvme_vfio_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-ublk_nvme_vfio_CPPFLAGS = $(ublk_nvme_vfio_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_nvme_vfio_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+ublk_nvme_vfio_CFLAGS = $(ublk_CFLAGS)
+ublk_nvme_vfio_CPPFLAGS = $(ublk_CPPFLAGS)
+ublk_nvme_vfio_LDADD = $(ublk_LDADD)
 
 ublk_sheepdog_SOURCES = $(TGT_DIR)/sheepdog/ublk.sheepdog.cpp $(TGT_DIR)/sheepdog/sheep.c $(TGT_DIR)/ublksrv_tgt.cpp
-ublk_sheepdog_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-ublk_sheepdog_CPPFLAGS = $(ublk_sheepdog_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_sheepdog_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+ublk_sheepdog_CFLAGS = $(ublk_CFLAGS)
+ublk_sheepdog_CPPFLAGS = $(ublk_CPPFLAGS)
+ublk_sheepdog_LDADD = $(ublk_LDADD)
 
 ublk_nfs_SOURCES = $(TGT_DIR)/ublk.nfs.cpp $(TGT_DIR)/ublksrv_tgt.cpp
-ublk_nfs_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
-ublk_nfs_CPPFLAGS = $(ublk_nfs_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_nfs_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS) -lnfs
+ublk_nfs_CFLAGS = $(ublk_CFLAGS)
+ublk_nfs_CPPFLAGS = $(ublk_CPPFLAGS)
+ublk_nfs_LDADD = $(ublk_LDADD) -lnfs
 
 demo_null_SOURCES = demo_null.c
-demo_null_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
+demo_null_CFLAGS = $(ublk_CFLAGS)
 demo_null_CPPFLAGS = $(demo_null_CFLAGS) -I$(top_srcdir)/include
-demo_null_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+demo_null_LDADD = $(ublk_LDADD)
 
 demo_event_SOURCES = demo_event.c
-demo_event_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
+demo_event_CFLAGS = $(ublk_CFLAGS)
 demo_event_CPPFLAGS = $(demo_event_CFLAGS) -I$(top_srcdir)/include
-demo_event_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+demo_event_LDADD = $(ublk_LDADD)
 
 ublk_user_id_SOURCES = utils/ublk_user_id.c
-ublk_user_id_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
+ublk_user_id_CFLAGS = $(ublk_CLFLAGS)
 ublk_user_id_CPPFLAGS = $(ublk_user_id_CFLAGS) -I$(top_srcdir)/include
-ublk_user_id_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+ublk_user_id_LDADD = $(ublk_LDADD)
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = ublksrv.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ ublk_SOURCES = $(TGT_DIR)/ublk.cpp $(TGT_DIR)/ublksrv_tgt.cpp
 
 ublk_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_CPPFLAGS = $(ublk_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
+ublk_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS) -luuid
 
 ublk_null_SOURCES = $(TGT_DIR)/ublk.null.cpp $(TGT_DIR)/ublksrv_tgt.cpp
 ublk_null_CFLAGS = $(ublk_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,10 @@ AC_ARG_ENABLE(
 dnl Check for liburing (required).
 PKG_CHECK_MODULES([LIBURING], [liburing >= 2.2])
 
+dnl Check for libuuid (required)
+AC_CHECK_HEADERS([uuid/uuid.h],,
+	AC_MSG_ERROR(libuuid is required))
+
 dnl Check if io_uring_prep_sendmsg_zc which isn't supported on 2.2 yet
 AC_MSG_CHECKING([for io_uring_prep_sendmsg_zc])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -237,6 +237,16 @@ dnl Check for linux/iommufd.h (required for nvme_vfio target)
 AC_CHECK_HEADERS([linux/iommufd.h])
 AM_CONDITIONAL([HAVE_IOMMUFD], [test "x$ac_cv_header_linux_iommufd_h" = "xyes"])
 
+if test "x$ac_cv_header_linux_iommufd_h" = "xyes"; then
+  dnl Check for vfio iommu detach
+  AC_CHECK_MEMBER([struct vfio_device_detach_iommufd_pt.pasid],
+    [with_type1_iommu=1],[],
+    [[#include <linux/vfio.h>]])
+fi
+if test "x$with_type1_iommu" = "x1"; then
+  AC_DEFINE(HAVE_TYPE1_IOMMU, 1, [Define to 1 if VFIO_DEVICE_ATTACH_IOMMUFD_PT is present])
+fi
+
 dnl Produce output files.
 AC_CONFIG_HEADERS([config.h])
 

--- a/include/ublk_cmd.h
+++ b/include/ublk_cmd.h
@@ -722,6 +722,10 @@ struct ublk_param_integrity {
 	__u8	pad[5];
 };
 
+struct ublk_param_uuid {
+	__u8 uuid[16];
+};
+
 struct ublk_params {
 	/*
 	 * Total length of parameters, userspace has to set 'len' for both
@@ -737,6 +741,7 @@ struct ublk_params {
 #define UBLK_PARAM_TYPE_DMA_ALIGN       (1 << 4)
 #define UBLK_PARAM_TYPE_SEGMENT         (1 << 5)
 #define UBLK_PARAM_TYPE_INTEGRITY       (1 << 6) /* requires UBLK_F_INTEGRITY */
+#define UBLK_PARAM_TYPE_UUID            (1 << 7)
 	__u32	types;			/* types of parameter included */
 
 	struct ublk_param_basic		basic;
@@ -746,6 +751,7 @@ struct ublk_params {
 	struct ublk_param_dma_align	dma;
 	struct ublk_param_segment	seg;
 	struct ublk_param_integrity	integrity;
+	struct ublk_param_uuid		uuid;
 };
 
 #endif

--- a/lib/ublksrv_json.cpp
+++ b/lib/ublksrv_json.cpp
@@ -2,6 +2,8 @@
 
 #include <config.h>
 
+#include <uuid/uuid.h>
+
 #include <iostream>
 #include "nlohmann/json.hpp"
 #include "ublksrv_priv.h"
@@ -138,8 +140,29 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ublk_param_integrity,
 	csum_type,
 	tag_size)
 
+namespace nlohmann
+{
+	template <>
+	struct adl_serializer<struct ublk_param_uuid> {
+		static struct ublk_param_uuid from_json(const json& j) {
+			struct ublk_param_uuid p_uuid;
+			std::string uuid_str = j.at("uuid");
+
+			uuid_parse(uuid_str.c_str(), p_uuid.uuid);
+			return {p_uuid};
+		}
+
+		static void to_json(json& j, const struct ublk_param_uuid p) {
+			char uuid_str[UUID_STR_LEN];
+
+			uuid_unparse(p.uuid, uuid_str);
+			j["uuid"] = uuid_str;
+		}
+	};
+}
+
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(struct ublk_params,
-	len, types, basic, discard, devt, zoned, dma, seg, integrity)
+	len, types, basic, discard, devt, zoned, dma, seg, integrity, uuid)
 
 struct ublksrv_tgt_jbuf *ublksrv_tgt_get_jbuf(const struct ublksrv_ctrl_dev *cdev)
 {

--- a/targets/nvme/ublk.nvme_vfio.cpp
+++ b/targets/nvme/ublk.nvme_vfio.cpp
@@ -425,7 +425,11 @@ static void nvme_log_numa_info(const struct nvme_vfio_tgt_data *data)
 
 static inline bool nvme_use_iommu(struct nvme_vfio_tgt_data *data)
 {
+#ifdef HAVE_TYPE1_IOMMU
 	return !data->use_noiommu && !data->force_noiommu;
+#else
+	return false;
+#endif
 }
 
 /* Check if controller supports SGL for NVM commands */
@@ -1325,6 +1329,7 @@ static void nvme_vfio_cleanup(struct nvme_vfio_tgt_data *data, bool shutdown_ctr
 	if (data->bar0 && data->bar0 != MAP_FAILED)
 		munmap((void *)data->bar0, data->bar0_size);
 
+#ifdef HAVE_TYPE1_IOMMU
 	if (data->iommufd >= 0) {
 		/* iommufd path: detach device, destroy IOAS, then close fds */
 		struct vfio_device_detach_iommufd_pt detach = {};
@@ -1341,6 +1346,7 @@ static void nvme_vfio_cleanup(struct nvme_vfio_tgt_data *data, bool shutdown_ctr
 			close(data->device_fd);
 		close(data->iommufd);
 	} else {
+#endif
 		/* Legacy noiommu path */
 		if (data->device_fd >= 0)
 			close(data->device_fd);
@@ -1348,8 +1354,9 @@ static void nvme_vfio_cleanup(struct nvme_vfio_tgt_data *data, bool shutdown_ctr
 			close(data->group_fd);
 		if (data->container_fd >= 0)
 			close(data->container_fd);
+#ifdef HAVE_TYPE1_IOMMU
 	}
-
+#endif
 	pthread_spin_destroy(&data->iova_lock);
 	nvme_dmabuf_pool_deinit(data);
 	nvme_adjust_hugepages(-(long)data->extra_hugepages);
@@ -1884,6 +1891,7 @@ err_close:
 	return -1;
 }
 
+#ifdef HAVE_IOMMU_TYPE1
 /*
  * Open VFIO cdev for a PCI device.
  * Scans /sys/bus/pci/devices/{pci}/vfio-dev/ to find the vfioN name,
@@ -1993,6 +2001,7 @@ err_close_iommufd:
 	data->iommufd = -1;
 	return -1;
 }
+#endif
 
 /* Per-queue private data */
 struct nvme_vfio_queue_data {
@@ -2048,11 +2057,14 @@ static int nvme_vfio_setup(struct nvme_vfio_tgt_data *data)
 		return -1;
 	}
 
+#ifdef HAVE_TYPE1_IOMMU
 	if (nvme_use_iommu(data)) {
 		/* IOMMU mode: use iommufd + VFIO cdev */
 		if (nvme_vfio_setup_iommufd(data) < 0)
 			return -1;
+		goto post_setup:
 	} else {
+#endif
 		/* NoIOMMU mode: use legacy VFIO container/group */
 		int version;
 
@@ -2085,7 +2097,9 @@ static int nvme_vfio_setup(struct nvme_vfio_tgt_data *data)
 			ublk_err("VFIO_GROUP_GET_DEVICE_FD: %s\n", strerror(errno));
 			return -1;
 		}
+#ifdef HAVE_TYPE1_IOMMU
 	}
+#endif
 
 	/* Common post-setup: device info, bus mastering, BAR0 mmap */
 	if (ioctl(data->device_fd, VFIO_DEVICE_GET_INFO, &device_info) < 0) {

--- a/targets/sheepdog/sheep.c
+++ b/targets/sheepdog/sheep.c
@@ -44,7 +44,7 @@ static uint32_t sd_inode_get_idx(struct sheepdog_vdi *sd_vdi,
 	vid = sd_vdi->inode.data_vdi_id[idx];
 	pthread_mutex_unlock(&sd_vdi->inode_lock);
 
-	return vid;
+	return oid_to_vid(vid);
 }
 
 /* locking is done by the caller */
@@ -451,7 +451,7 @@ recheck:
 		return vid;
 
 	if (!sd_refresh_required(fd, sd_vdi))
-		return 0;
+		return vid;
 
 	ret = sd_read_inode(fd, sd_vdi, false);
 	if (ret < 0)
@@ -482,7 +482,7 @@ int sd_exec_read(int fd, struct sheepdog_vdi *sd_vdi,
 	vid = ret;
 	oid = vid_to_data_oid(vid, idx);
 	ublk_err("%s: read oid %lx from vid %x\n",
-		 __func__, oid, vid);
+		 __func__, oid, vid, idx);
 	ret = sd_read_object(fd, sd_io, oid, (void *)iod->addr,
 			     start, total, &need_reload);
 	if (ret < 0)
@@ -506,8 +506,9 @@ int sd_exec_discard(int fd, struct sheepdog_vdi *sd_vdi,
 	ret = sd_resolve_vid(fd, sd_vdi, idx);
 	if (ret < 0)
 		return ret;
-	if (!ret && write_zeroes) {
-		memset((void *)iod->addr, 0, total);
+	if (!ret) {
+		if (write_zeroes)
+			memset((void *)iod->addr, 0, total);
 		return 0;
 	}
 	orig_vid = ret;
@@ -518,7 +519,7 @@ retry:
 	sd_io->req.flags |= SD_FLAG_CMD_TGT;
 
 	pthread_mutex_lock(&sd_vdi->inode_lock);
-	orig_vid = sd_vdi->inode.data_vdi_id[idx];
+	orig_vid = oid_to_vid(sd_vdi->inode.data_vdi_id[idx]);
 	sd_vdi->inode.data_vdi_id[idx] = new_vid;
 	pthread_mutex_unlock(&sd_vdi->inode_lock);
 
@@ -600,6 +601,7 @@ static void sd_prep_write(struct sheepdog_vdi *sd_vdi,
 	pthread_mutex_unlock(&sd_vdi->inode_lock);
 
 }
+
 int sd_exec_write(int fd, struct sheepdog_vdi *sd_vdi,
 		const struct ublksrv_io_desc *iod,
 		struct sd_io_context *sd_io)
@@ -609,7 +611,6 @@ int sd_exec_write(int fd, struct sheepdog_vdi *sd_vdi,
 	uint32_t total = iod->nr_sectors << 9;
 	uint64_t start = offset % object_size;
 	uint32_t idx = offset / object_size;
-	uint64_t oid = 0, cow_oid = 0;
 	int ret;
 
 retry:
@@ -617,8 +618,6 @@ retry:
 	sd_prep_write(sd_vdi, sd_io, idx);
 
 	sd_io->addr = (void *)iod->addr;
-	sd_io->req.obj.oid = oid;
-	sd_io->req.obj.cow_oid = cow_oid;
 	sd_io->req.obj.offset = start;
 	sd_io->req.data_length = total;
 	sd_io->req.obj.copies = sd_vdi->inode.nr_copies;

--- a/targets/sheepdog/sheepdog_proto.h
+++ b/targets/sheepdog/sheepdog_proto.h
@@ -331,6 +331,11 @@ struct recovery_throttling {
 	bool throttling;
 };
 
+#define SD_DEFAULT_STORE_POLICY 0
+#define SD_HYPER_STORE_POLICY 1
+#define SD_UUID_POLICY_MASK 0x80
+#define SD_STORE_POLICY_MASK 0x7f
+
 struct sd_inode {
 	char name[SD_MAX_VDI_LEN];
 	char tag[SD_MAX_VDI_TAG_LEN];
@@ -363,6 +368,15 @@ struct sd_indirect_idx {
 	uint32_t idx; /* Max index of data object within this indirect node */
 	uint64_t oid;
 };
+
+#define SD_INODE_STORE_POLICY(i) ((i)->store_policy & SD_STORE_POLICY_MASK)
+#define SD_INODE_USE_UUID(i) ((i)->store_policy & SD_UUID_POLICY_MASK)
+
+static inline bool sd_store_policy_is_hyper(const struct sd_inode *inode)
+{
+	uint8_t policy = inode->store_policy & SD_STORE_POLICY_MASK;
+	return policy == SD_HYPER_STORE_POLICY;
+}
 
 #define INODE_BTREE_MAGIC	0x6274
 

--- a/targets/sheepdog/ublk.sheepdog.cpp
+++ b/targets/sheepdog/ublk.sheepdog.cpp
@@ -12,6 +12,7 @@
 #include <linux/falloc.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include <uuid/uuid.h>
 
 #include "ublksrv_tgt.h"
 #include "sheepdog_proto.h"
@@ -160,12 +161,14 @@ static int sheepdog_init_tgt(struct ublksrv_dev *ub_dev, int type,
 		{ "send_tmo",	required_argument, NULL, 's'},
 		{ "read_tmo",	required_argument, NULL, 'r'},
 		{ "lbs",	required_argument, NULL, 'b'},
+		{ "uuid",	required_argument, NULL, 'U'},
 		{ "unlock",	no_argument, &unlock, 'u'},
 		{ NULL }
 	};
 	int opt, lbs = 9, ret;
 	unsigned long send_tmo = SD_SEND_TMO, recv_tmo = SD_RECV_TMO;
 	char *vdi_name = NULL;
+	uuid_t uuid;
 	const char *cluster_host = "127.0.0.1";
 	const char *cluster_port = "7000";
 	struct sheepdog_dev *dev;
@@ -195,8 +198,9 @@ static int sheepdog_init_tgt(struct ublksrv_dev *ub_dev, int type,
 		return sheepdog_recover_tgt(ub_dev, 0);
 
 	strcpy(tgt_json.name, "sheepdog");
+	uuid_clear(uuid);
 
-	while ((opt = getopt_long(argc, argv, "h:p:v:b:s:r:",
+	while ((opt = getopt_long(argc, argv, "h:p:v:b:s:r:U:",
 				  sheepdog_longopts, NULL)) != -1) {
 		switch (opt) {
 		case 'v':
@@ -232,6 +236,10 @@ static int sheepdog_init_tgt(struct ublksrv_dev *ub_dev, int type,
 			if (recv_tmo < send_tmo)
 				return -EINVAL;
 			break;
+		case 'U':
+			if (uuid_parse(optarg, uuid))
+				return -EINVAL;
+			break;
 		}
 	}
 
@@ -262,7 +270,14 @@ static int sheepdog_init_tgt(struct ublksrv_dev *ub_dev, int type,
 
 	ublk_json_write_tgt_ulong(cdev, "vid", dev->vdi.vid);
 	ublk_json_write_tgt_ulong(cdev, "ctime", dev->vdi.inode.create_time);
-
+	if (uuid_is_null(uuid) && SD_INODE_USE_UUID(&dev->vdi.inode)) {
+		memcpy((char *)uuid, &dev->vdi.inode.vm_clock_nsec, 8);
+		memcpy((char *)(uuid + 8), &dev->vdi.inode.vm_state_size, 8);
+	}
+	if (!uuid_is_null(uuid)) {
+		memcpy(p.uuid.uuid, uuid, 16);
+		p.types |= UBLK_PARAM_TYPE_UUID;
+	}
 	p.basic.physical_bs_shift = dev->vdi.inode.block_size_shift;
 	p.basic.chunk_sectors = 1 << (p.basic.physical_bs_shift - 9);
 	p.basic.dev_sectors = dev->vdi.inode.vdi_size >> 9;


### PR DESCRIPTION
Add a new 'uuid' ublk parameter to allow an ublk device to specify an UUID for device identification.