### PR TITLE
nvme_vfio: add legacy VFIO container mode & refactor nvme_vfio_iommufd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,9 @@ ublk_nbd_CPPFLAGS = $(ublk_nbd_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_nbd_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
 ublk_nvme_vfio_SOURCES = $(TGT_DIR)/nvme/ublk.nvme_vfio.cpp $(TGT_DIR)/dma_buf.c $(TGT_DIR)/ublksrv_tgt.cpp
+if HAVE_VFIO_IOMMUFD
+ublk_nvme_vfio_SOURCES += $(TGT_DIR)/nvme/vfio_iommufd.c
+endif
 ublk_nvme_vfio_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_nvme_vfio_CPPFLAGS = $(ublk_nvme_vfio_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_nvme_vfio_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ if HAVE_LIBISCSI
 sbin_PROGRAMS += ublk.iscsi
 endif
 
-if HAVE_IOMMUFD
+if HAVE_VFIO
 sbin_PROGRAMS += ublk.nvme_vfio
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,7 @@ AC_CHECK_HEADERS([linux/iommufd.h])
 AM_CONDITIONAL([HAVE_IOMMUFD], [test "x$ac_cv_header_linux_iommufd_h" = "xyes"])
 
 dnl Check for VFIO iommufd cdev support (requires both headers + cdev ioctls)
+have_vfio_iommufd=no
 if test "x$ac_cv_header_linux_iommufd_h" = "xyes"; then
     AC_MSG_CHECKING([for VFIO iommufd cdev support])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
@@ -249,9 +250,11 @@ if test "x$ac_cv_header_linux_iommufd_h" = "xyes"; then
         (void)x; (void)a;
     ]])],
     [AC_MSG_RESULT([yes])
+     have_vfio_iommufd=yes
      AC_DEFINE([HAVE_VFIO_IOMMUFD], [1], [Define to 1 if VFIO iommufd cdev is supported])],
     [AC_MSG_RESULT([no])])
 fi
+AM_CONDITIONAL([HAVE_VFIO_IOMMUFD], [test "x$have_vfio_iommufd" = "xyes"])
 
 dnl Produce output files.
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -229,9 +229,29 @@ if test -z "$DOXYGEN"; then
 fi
 AM_CONDITIONAL([HAVE_DOXYGEN], [test -n "$DOXYGEN"])
 
-dnl Check for linux/iommufd.h (required for nvme_vfio target)
+dnl Check for linux/vfio.h (required for nvme_vfio target)
+AC_CHECK_HEADERS([linux/vfio.h])
+AM_CONDITIONAL([HAVE_VFIO], [test "x$ac_cv_header_linux_vfio_h" = "xyes"])
+
+dnl Check for linux/iommufd.h
 AC_CHECK_HEADERS([linux/iommufd.h])
 AM_CONDITIONAL([HAVE_IOMMUFD], [test "x$ac_cv_header_linux_iommufd_h" = "xyes"])
+
+dnl Check for VFIO iommufd cdev support (requires both headers + cdev ioctls)
+if test "x$ac_cv_header_linux_iommufd_h" = "xyes"; then
+    AC_MSG_CHECKING([for VFIO iommufd cdev support])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        #include <linux/vfio.h>
+        #include <linux/iommufd.h>
+    ]], [[
+        int x = VFIO_DEVICE_ATTACH_IOMMUFD_PT;
+        struct iommu_ioas_alloc a;
+        (void)x; (void)a;
+    ]])],
+    [AC_MSG_RESULT([yes])
+     AC_DEFINE([HAVE_VFIO_IOMMUFD], [1], [Define to 1 if VFIO iommufd cdev is supported])],
+    [AC_MSG_RESULT([no])])
+fi
 
 dnl Produce output files.
 AC_CONFIG_HEADERS([config.h])

--- a/targets/nvme/ublk.nvme_vfio.cpp
+++ b/targets/nvme/ublk.nvme_vfio.cpp
@@ -52,9 +52,6 @@
 #include <sys/epoll.h>
 #include <limits.h>
 #include <linux/vfio.h>
-#ifdef HAVE_VFIO_IOMMUFD
-#include <linux/iommufd.h>
-#endif
 #include <dirent.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -66,6 +63,7 @@
 #include "nvme.h"
 
 #include "dma_buf.h"
+#include "vfio_iommufd.h"
 
 #define PAGE_SIZE 4096
 #define ADMIN_Q_SIZE 64
@@ -433,11 +431,7 @@ static inline bool nvme_use_iommu(struct nvme_vfio_tgt_data *data)
 
 static inline bool nvme_use_iommufd(struct nvme_vfio_tgt_data *data)
 {
-#ifdef HAVE_VFIO_IOMMUFD
-	return nvme_use_iommu(data) && !data->force_legacy;
-#else
-	return false;
-#endif
+	return vfio_iommufd_enabled() && nvme_use_iommu(data) && !data->force_legacy;
 }
 
 /* Check if controller supports SGL for NVM commands */
@@ -482,26 +476,9 @@ static int nvme_do_vfio_map(struct nvme_vfio_tgt_data *data,
 	if (!nvme_use_iommu(data))
 		return 0;
 
-#ifdef HAVE_VFIO_IOMMUFD
-	if (data->iommufd >= 0) {
-		struct iommu_ioas_map map = {};
-
-		map.size = sizeof(map);
-		map.flags = IOMMU_IOAS_MAP_FIXED_IOVA |
-			    IOMMU_IOAS_MAP_WRITEABLE |
-			    IOMMU_IOAS_MAP_READABLE;
-		map.ioas_id = data->ioas_id;
-		map.user_va = (__u64)vaddr;
-		map.length = map_size;
-		map.iova = iova;
-
-		if (ioctl(data->iommufd, IOMMU_IOAS_MAP, &map) < 0) {
-			ublk_err("IOMMU_IOAS_MAP: %s\n", strerror(errno));
-			return -1;
-		}
-		return 0;
-	}
-#endif
+	if (data->iommufd >= 0)
+		return vfio_iommufd_map_dma(data->iommufd, data->ioas_id,
+					    vaddr, iova, map_size);
 
 	{
 		struct vfio_iommu_type1_dma_map dma_map = {};
@@ -892,18 +869,10 @@ static void nvme_unmap_dma(struct nvme_vfio_tgt_data *data,
 		return;
 
 	if (nvme_use_iommu(data)) {
-#ifdef HAVE_VFIO_IOMMUFD
 		if (data->iommufd >= 0) {
-			struct iommu_ioas_unmap unmap = {};
-
-			unmap.size = sizeof(unmap);
-			unmap.ioas_id = data->ioas_id;
-			unmap.iova = mapping->iova;
-			unmap.length = mapping->size;
-			ioctl(data->iommufd, IOMMU_IOAS_UNMAP, &unmap);
-		} else
-#endif
-		{
+			vfio_iommufd_unmap_dma(data->iommufd, data->ioas_id,
+					       mapping->iova, mapping->size);
+		} else {
 			struct vfio_iommu_type1_dma_unmap dma_unmap = {};
 
 			dma_unmap.argsz = sizeof(dma_unmap);
@@ -1375,25 +1344,10 @@ static void nvme_vfio_cleanup(struct nvme_vfio_tgt_data *data, bool shutdown_ctr
 	if (data->bar0 && data->bar0 != MAP_FAILED)
 		munmap((void *)data->bar0, data->bar0_size);
 
-#ifdef HAVE_VFIO_IOMMUFD
 	if (data->iommufd >= 0) {
-		/* iommufd path: detach device, destroy IOAS, then close fds */
-		struct vfio_device_detach_iommufd_pt detach = {};
-		struct iommu_destroy destroy = {};
-
-		detach.argsz = sizeof(detach);
-		ioctl(data->device_fd, VFIO_DEVICE_DETACH_IOMMUFD_PT, &detach);
-
-		destroy.size = sizeof(destroy);
-		destroy.id = data->ioas_id;
-		ioctl(data->iommufd, IOMMU_DESTROY, &destroy);
-
-		if (data->device_fd >= 0)
-			close(data->device_fd);
-		close(data->iommufd);
-	} else
-#endif
-	{
+		vfio_iommufd_cleanup(data->iommufd, data->device_fd,
+				     data->ioas_id);
+	} else {
 		/* Legacy container path (TYPE1 IOMMU or NoIOMMU) */
 		if (data->device_fd >= 0)
 			close(data->device_fd);
@@ -1937,118 +1891,6 @@ err_close:
 	return -1;
 }
 
-#ifdef HAVE_VFIO_IOMMUFD
-/*
- * Open VFIO cdev for a PCI device.
- * Scans /sys/bus/pci/devices/{pci}/vfio-dev/ to find the vfioN name,
- * then opens /dev/vfio/devices/vfioN.
- */
-static int nvme_open_vfio_cdev(const char *pci_addr)
-{
-	char sysfs_path[256];
-	DIR *dir;
-	struct dirent *entry;
-	char dev_path[256];
-	int fd = -1;
-
-	snprintf(sysfs_path, sizeof(sysfs_path),
-		 "/sys/bus/pci/devices/%s/vfio-dev", pci_addr);
-
-	dir = opendir(sysfs_path);
-	if (!dir) {
-		ublk_err("opendir %s: %s\n", sysfs_path, strerror(errno));
-		return -1;
-	}
-
-	while ((entry = readdir(dir)) != NULL) {
-		if (entry->d_name[0] == '.')
-			continue;
-		snprintf(dev_path, sizeof(dev_path),
-			 "/dev/vfio/devices/%s", entry->d_name);
-		fd = open(dev_path, O_RDWR);
-		if (fd < 0)
-			ublk_err("open %s: %s\n", dev_path, strerror(errno));
-		break;
-	}
-
-	closedir(dir);
-
-	if (fd < 0)
-		ublk_err("No VFIO cdev found for %s\n", pci_addr);
-
-	return fd;
-}
-
-/*
- * Setup iommufd-based VFIO device access.
- * Opens /dev/iommu, the VFIO cdev, binds the device to iommufd,
- * allocates an IOAS, and attaches the device to it.
- */
-static int nvme_vfio_setup_iommufd(struct nvme_vfio_tgt_data *data)
-{
-	struct vfio_device_bind_iommufd bind = {};
-	struct iommu_ioas_alloc ioas_alloc = {};
-	struct vfio_device_attach_iommufd_pt attach = {};
-
-	/* Open /dev/iommu */
-	data->iommufd = open("/dev/iommu", O_RDWR);
-	if (data->iommufd < 0) {
-		ublk_err("open /dev/iommu: %s\n", strerror(errno));
-		return -1;
-	}
-
-	/* Open VFIO cdev */
-	data->device_fd = nvme_open_vfio_cdev(data->pci_addr);
-	if (data->device_fd < 0)
-		goto err_close_iommufd;
-
-	/* Bind device to iommufd */
-	bind.argsz = sizeof(bind);
-	bind.flags = 0;
-	bind.iommufd = data->iommufd;
-	if (ioctl(data->device_fd, VFIO_DEVICE_BIND_IOMMUFD, &bind) < 0) {
-		ublk_err("VFIO_DEVICE_BIND_IOMMUFD: %s\n", strerror(errno));
-		goto err_close_device;
-	}
-	data->dev_id = bind.out_devid;
-
-	/* Allocate IOAS */
-	ioas_alloc.size = sizeof(ioas_alloc);
-	ioas_alloc.flags = 0;
-	if (ioctl(data->iommufd, IOMMU_IOAS_ALLOC, &ioas_alloc) < 0) {
-		ublk_err("IOMMU_IOAS_ALLOC: %s\n", strerror(errno));
-		goto err_close_device;
-	}
-	data->ioas_id = ioas_alloc.out_ioas_id;
-
-	/* Attach device to IOAS */
-	attach.argsz = sizeof(attach);
-	attach.flags = 0;
-	attach.pt_id = data->ioas_id;
-	if (ioctl(data->device_fd, VFIO_DEVICE_ATTACH_IOMMUFD_PT, &attach) < 0) {
-		ublk_err("VFIO_DEVICE_ATTACH_IOMMUFD_PT: %s\n", strerror(errno));
-		goto err_destroy_ioas;
-	}
-
-	return 0;
-
-err_destroy_ioas:
-	{
-		struct iommu_destroy destroy = {};
-		destroy.size = sizeof(destroy);
-		destroy.id = data->ioas_id;
-		ioctl(data->iommufd, IOMMU_DESTROY, &destroy);
-	}
-err_close_device:
-	close(data->device_fd);
-	data->device_fd = -1;
-err_close_iommufd:
-	close(data->iommufd);
-	data->iommufd = -1;
-	return -1;
-}
-#endif /* HAVE_VFIO_IOMMUFD */
-
 /*
  * Setup legacy VFIO container/group device access.
  * Handles both TYPE1 IOMMU and NoIOMMU modes.
@@ -2156,15 +1998,14 @@ static int nvme_vfio_setup(struct nvme_vfio_tgt_data *data)
 		return -1;
 	}
 
-#ifdef HAVE_VFIO_IOMMUFD
 	if (nvme_use_iommufd(data)) {
 		/* iommufd mode: use iommufd + VFIO cdev */
-		if (nvme_vfio_setup_iommufd(data) < 0)
+		if (vfio_iommufd_setup(data->pci_addr, &data->iommufd,
+				       &data->device_fd, &data->ioas_id,
+				       &data->dev_id) < 0)
 			return -1;
 		nvme_log("Using iommufd mode\n");
-	} else
-#endif
-	{
+	} else {
 		/* Legacy container mode (TYPE1 IOMMU or NoIOMMU) */
 		if (nvme_vfio_setup_container(data) < 0)
 			return -1;

--- a/targets/nvme/ublk.nvme_vfio.cpp
+++ b/targets/nvme/ublk.nvme_vfio.cpp
@@ -52,7 +52,9 @@
 #include <sys/epoll.h>
 #include <limits.h>
 #include <linux/vfio.h>
+#ifdef HAVE_VFIO_IOMMUFD
 #include <linux/iommufd.h>
+#endif
 #include <dirent.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -186,8 +188,9 @@ struct nvme_vfio_tgt_data {
 	__u32 ioas_id;
 	__u32 dev_id;
 
-	/* NoIOMMU mode flag */
+	/* Mode control flags */
 	int force_noiommu;	/* --noiommu flag: use virtual addresses as IOVAs */
+	int force_legacy;	/* --force-legacy flag: use container instead of iommufd */
 
 	/* MMIO mapping */
 	volatile void *bar0;
@@ -428,6 +431,15 @@ static inline bool nvme_use_iommu(struct nvme_vfio_tgt_data *data)
 	return !data->use_noiommu && !data->force_noiommu;
 }
 
+static inline bool nvme_use_iommufd(struct nvme_vfio_tgt_data *data)
+{
+#ifdef HAVE_VFIO_IOMMUFD
+	return nvme_use_iommu(data) && !data->force_legacy;
+#else
+	return false;
+#endif
+}
+
 /* Check if controller supports SGL for NVM commands */
 static inline bool nvme_sgl_supported(struct nvme_vfio_tgt_data *data)
 {
@@ -457,28 +469,53 @@ static __u64 nvme_get_iova(struct nvme_vfio_tgt_data *data, void *vaddr, size_t 
 }
 
 /*
- * Perform VFIO DMA mapping if needed
+ * Perform VFIO DMA mapping if needed.
+ * iommufd mode: uses IOMMU_IOAS_MAP
+ * container mode: uses VFIO_IOMMU_MAP_DMA
+ * noiommu mode: no mapping needed (physical addresses used directly)
  */
 static int nvme_do_vfio_map(struct nvme_vfio_tgt_data *data,
 			    void *vaddr, __u64 iova, size_t size)
 {
-	struct iommu_ioas_map map = {};
+	size_t map_size = (size + PAGE_SIZE - 1) & ~((__u64)PAGE_SIZE - 1);
 
 	if (!nvme_use_iommu(data))
 		return 0;
 
-	map.size = sizeof(map);
-	map.flags = IOMMU_IOAS_MAP_FIXED_IOVA |
-		    IOMMU_IOAS_MAP_WRITEABLE |
-		    IOMMU_IOAS_MAP_READABLE;
-	map.ioas_id = data->ioas_id;
-	map.user_va = (__u64)vaddr;
-	map.length = (size + PAGE_SIZE - 1) & ~((__u64)PAGE_SIZE - 1);
-	map.iova = iova;
+#ifdef HAVE_VFIO_IOMMUFD
+	if (data->iommufd >= 0) {
+		struct iommu_ioas_map map = {};
 
-	if (ioctl(data->iommufd, IOMMU_IOAS_MAP, &map) < 0) {
-		ublk_err("IOMMU_IOAS_MAP: %s\n", strerror(errno));
-		return -1;
+		map.size = sizeof(map);
+		map.flags = IOMMU_IOAS_MAP_FIXED_IOVA |
+			    IOMMU_IOAS_MAP_WRITEABLE |
+			    IOMMU_IOAS_MAP_READABLE;
+		map.ioas_id = data->ioas_id;
+		map.user_va = (__u64)vaddr;
+		map.length = map_size;
+		map.iova = iova;
+
+		if (ioctl(data->iommufd, IOMMU_IOAS_MAP, &map) < 0) {
+			ublk_err("IOMMU_IOAS_MAP: %s\n", strerror(errno));
+			return -1;
+		}
+		return 0;
+	}
+#endif
+
+	{
+		struct vfio_iommu_type1_dma_map dma_map = {};
+
+		dma_map.argsz = sizeof(dma_map);
+		dma_map.flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE;
+		dma_map.vaddr = (__u64)vaddr;
+		dma_map.iova = iova;
+		dma_map.size = map_size;
+
+		if (ioctl(data->container_fd, VFIO_IOMMU_MAP_DMA, &dma_map) < 0) {
+			ublk_err("VFIO_IOMMU_MAP_DMA: %s\n", strerror(errno));
+			return -1;
+		}
 	}
 
 	return 0;
@@ -855,13 +892,26 @@ static void nvme_unmap_dma(struct nvme_vfio_tgt_data *data,
 		return;
 
 	if (nvme_use_iommu(data)) {
-		struct iommu_ioas_unmap unmap = {};
+#ifdef HAVE_VFIO_IOMMUFD
+		if (data->iommufd >= 0) {
+			struct iommu_ioas_unmap unmap = {};
 
-		unmap.size = sizeof(unmap);
-		unmap.ioas_id = data->ioas_id;
-		unmap.iova = mapping->iova;
-		unmap.length = mapping->size;
-		ioctl(data->iommufd, IOMMU_IOAS_UNMAP, &unmap);
+			unmap.size = sizeof(unmap);
+			unmap.ioas_id = data->ioas_id;
+			unmap.iova = mapping->iova;
+			unmap.length = mapping->size;
+			ioctl(data->iommufd, IOMMU_IOAS_UNMAP, &unmap);
+		} else
+#endif
+		{
+			struct vfio_iommu_type1_dma_unmap dma_unmap = {};
+
+			dma_unmap.argsz = sizeof(dma_unmap);
+			dma_unmap.iova = mapping->iova;
+			dma_unmap.size = mapping->size;
+			ioctl(data->container_fd, VFIO_IOMMU_UNMAP_DMA,
+			      &dma_unmap);
+		}
 	}
 
 	mapping->vaddr = 0;
@@ -1325,6 +1375,7 @@ static void nvme_vfio_cleanup(struct nvme_vfio_tgt_data *data, bool shutdown_ctr
 	if (data->bar0 && data->bar0 != MAP_FAILED)
 		munmap((void *)data->bar0, data->bar0_size);
 
+#ifdef HAVE_VFIO_IOMMUFD
 	if (data->iommufd >= 0) {
 		/* iommufd path: detach device, destroy IOAS, then close fds */
 		struct vfio_device_detach_iommufd_pt detach = {};
@@ -1340,8 +1391,10 @@ static void nvme_vfio_cleanup(struct nvme_vfio_tgt_data *data, bool shutdown_ctr
 		if (data->device_fd >= 0)
 			close(data->device_fd);
 		close(data->iommufd);
-	} else {
-		/* Legacy noiommu path */
+	} else
+#endif
+	{
+		/* Legacy container path (TYPE1 IOMMU or NoIOMMU) */
 		if (data->device_fd >= 0)
 			close(data->device_fd);
 		if (data->group_fd >= 0)
@@ -1884,6 +1937,7 @@ err_close:
 	return -1;
 }
 
+#ifdef HAVE_VFIO_IOMMUFD
 /*
  * Open VFIO cdev for a PCI device.
  * Scans /sys/bus/pci/devices/{pci}/vfio-dev/ to find the vfioN name,
@@ -1993,6 +2047,59 @@ err_close_iommufd:
 	data->iommufd = -1;
 	return -1;
 }
+#endif /* HAVE_VFIO_IOMMUFD */
+
+/*
+ * Setup legacy VFIO container/group device access.
+ * Handles both TYPE1 IOMMU and NoIOMMU modes.
+ */
+static int nvme_vfio_setup_container(struct nvme_vfio_tgt_data *data)
+{
+	int version, vfio_ext;
+
+	data->container_fd = open("/dev/vfio/vfio", O_RDWR);
+	if (data->container_fd < 0) {
+		ublk_err("open /dev/vfio/vfio: %s\n", strerror(errno));
+		return -1;
+	}
+
+	version = ioctl(data->container_fd, VFIO_GET_API_VERSION);
+	if (version != VFIO_API_VERSION) {
+		ublk_err("VFIO API version mismatch\n");
+		goto err;
+	}
+
+	vfio_ext = nvme_use_iommu(data) ? VFIO_TYPE1_IOMMU : VFIO_NOIOMMU_IOMMU;
+	if (!ioctl(data->container_fd, VFIO_CHECK_EXTENSION, vfio_ext)) {
+		ublk_err("VFIO %s not supported\n",
+			 nvme_use_iommu(data) ? "TYPE1 IOMMU" : "no-IOMMU");
+		goto err;
+	}
+
+	data->group_fd = nvme_open_vfio_group(data->iommu_group,
+					      data->container_fd,
+					      &data->use_noiommu);
+	if (data->group_fd < 0)
+		goto err;
+
+	data->device_fd = ioctl(data->group_fd, VFIO_GROUP_GET_DEVICE_FD,
+				data->pci_addr);
+	if (data->device_fd < 0) {
+		ublk_err("VFIO_GROUP_GET_DEVICE_FD: %s\n", strerror(errno));
+		goto err;
+	}
+
+	return 0;
+
+err:
+	if (data->group_fd >= 0) {
+		close(data->group_fd);
+		data->group_fd = -1;
+	}
+	close(data->container_fd);
+	data->container_fd = -1;
+	return -1;
+}
 
 /* Per-queue private data */
 struct nvme_vfio_queue_data {
@@ -2027,8 +2134,9 @@ static int nvme_vfio_setup_tgt(struct ublksrv_dev *dev)
  * Setup VFIO device and map BAR0.
  * Called after data->pci_addr is set.
  *
- * IOMMU mode:   uses iommufd + VFIO cdev (/dev/iommu + /dev/vfio/devices/vfioN)
- * NoIOMMU mode: uses legacy VFIO container/group (/dev/vfio/vfio + /dev/vfio/{group})
+ * iommufd mode:   iommufd + VFIO cdev (/dev/iommu + /dev/vfio/devices/vfioN)
+ * container mode: legacy container/group + TYPE1 IOMMU (VFIO_IOMMU_MAP_DMA)
+ * noiommu mode:   legacy container/group + no IOMMU (physical addresses)
  */
 static int nvme_vfio_setup(struct nvme_vfio_tgt_data *data)
 {
@@ -2048,43 +2156,20 @@ static int nvme_vfio_setup(struct nvme_vfio_tgt_data *data)
 		return -1;
 	}
 
-	if (nvme_use_iommu(data)) {
-		/* IOMMU mode: use iommufd + VFIO cdev */
+#ifdef HAVE_VFIO_IOMMUFD
+	if (nvme_use_iommufd(data)) {
+		/* iommufd mode: use iommufd + VFIO cdev */
 		if (nvme_vfio_setup_iommufd(data) < 0)
 			return -1;
-	} else {
-		/* NoIOMMU mode: use legacy VFIO container/group */
-		int version;
-
-		data->container_fd = open("/dev/vfio/vfio", O_RDWR);
-		if (data->container_fd < 0) {
-			ublk_err("open /dev/vfio/vfio: %s\n", strerror(errno));
+		nvme_log("Using iommufd mode\n");
+	} else
+#endif
+	{
+		/* Legacy container mode (TYPE1 IOMMU or NoIOMMU) */
+		if (nvme_vfio_setup_container(data) < 0)
 			return -1;
-		}
-
-		version = ioctl(data->container_fd, VFIO_GET_API_VERSION);
-		if (version != VFIO_API_VERSION) {
-			ublk_err("VFIO API version mismatch\n");
-			return -1;
-		}
-
-		if (!ioctl(data->container_fd, VFIO_CHECK_EXTENSION, VFIO_NOIOMMU_IOMMU)) {
-			ublk_err("VFIO no-IOMMU not supported\n");
-			return -1;
-		}
-
-		data->group_fd = nvme_open_vfio_group(data->iommu_group,
-						      data->container_fd,
-						      &data->use_noiommu);
-		if (data->group_fd < 0)
-			return -1;
-
-		data->device_fd = ioctl(data->group_fd, VFIO_GROUP_GET_DEVICE_FD,
-					data->pci_addr);
-		if (data->device_fd < 0) {
-			ublk_err("VFIO_GROUP_GET_DEVICE_FD: %s\n", strerror(errno));
-			return -1;
-		}
+		nvme_log("Using legacy container mode (%s)\n",
+			 nvme_use_iommu(data) ? "TYPE1 IOMMU" : "NoIOMMU");
 	}
 
 	/* Common post-setup: device info, bus mastering, BAR0 mmap */
@@ -2128,15 +2213,18 @@ static int nvme_vfio_init_tgt(struct ublksrv_dev *dev, int type, int argc, char 
 	__u64 cap;
 	int opt;
 	int force_noiommu = 0;
+	int force_legacy = 0;
 	struct ublksrv_tgt_base_json tgt_json = { 0 };
 	struct ublk_params p = {};
 	enum {
 		OPT_PCI = 256,
 		OPT_NOIOMMU,
+		OPT_FORCE_LEGACY,
 	};
 	static const struct option longopts[] = {
 		{ "pci",		required_argument, NULL, OPT_PCI },
 		{ "noiommu",		no_argument, NULL, OPT_NOIOMMU },
+		{ "force-legacy",	no_argument, NULL, OPT_FORCE_LEGACY },
 		{ NULL }
 	};
 	size_t hps = nvme_get_hugepage_size();
@@ -2197,6 +2285,9 @@ static int nvme_vfio_init_tgt(struct ublksrv_dev *dev, int type, int argc, char 
 		case OPT_NOIOMMU:
 			force_noiommu = 1;
 			break;
+		case OPT_FORCE_LEGACY:
+			force_legacy = 1;
+			break;
 		}
 	}
 
@@ -2215,6 +2306,7 @@ static int nvme_vfio_init_tgt(struct ublksrv_dev *dev, int type, int argc, char 
 
 	dev->tgt.tgt_data = data;
 	data->force_noiommu = force_noiommu;
+	data->force_legacy = force_legacy;
 	data->user_copy = info->flags & UBLK_F_USER_COPY;
 
 	/* Enable noiommu mode if requested */
@@ -2432,9 +2524,10 @@ static void nvme_vfio_free_io_buf(const struct ublksrv_queue *q, void *buf, int 
 
 static void nvme_vfio_cmd_usage(void)
 {
-	printf("\tnvme_vfio: --pci PCI_ADDR [--noiommu]\n");
+	printf("\tnvme_vfio: --pci PCI_ADDR [--noiommu] [--force-legacy]\n");
 	printf("\t  --pci: PCI address of NVMe device (e.g., 0000:01:00.0)\n");
 	printf("\t  --noiommu: Force noiommu mode (use virtual addresses as IOVAs)\n");
+	printf("\t  --force-legacy: Force legacy VFIO container mode instead of iommufd\n");
 }
 
 static const struct ublksrv_tgt_type nvme_vfio_tgt_type = {

--- a/targets/nvme/vfio_iommufd.c
+++ b/targets/nvme/vfio_iommufd.c
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT or GPL-2.0-only
+/*
+ * VFIO iommufd cdev support for nvme_vfio target.
+ *
+ * This file is only compiled when HAVE_VFIO_IOMMUFD is defined.
+ * It provides setup, cleanup, and DMA mapping operations using
+ * the iommufd + VFIO cdev interface.
+ */
+#include <config.h>
+
+#include <linux/vfio.h>
+#include <linux/iommufd.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <string.h>
+#include <errno.h>
+
+#include <sched.h>
+#include "ublksrv_utils.h"
+#include "vfio_iommufd.h"
+
+#define PAGE_SIZE 4096
+
+/*
+ * Open VFIO cdev for a PCI device.
+ * Scans /sys/bus/pci/devices/{pci}/vfio-dev/ to find the vfioN name,
+ * then opens /dev/vfio/devices/vfioN.
+ */
+static int vfio_open_cdev(const char *pci_addr)
+{
+	char sysfs_path[256];
+	DIR *dir;
+	struct dirent *entry;
+	char dev_path[256];
+	int fd = -1;
+
+	snprintf(sysfs_path, sizeof(sysfs_path),
+		 "/sys/bus/pci/devices/%s/vfio-dev", pci_addr);
+
+	dir = opendir(sysfs_path);
+	if (!dir) {
+		ublk_err( "opendir %s: %s\n", sysfs_path, strerror(errno));
+		return -1;
+	}
+
+	while ((entry = readdir(dir)) != NULL) {
+		if (entry->d_name[0] == '.')
+			continue;
+		snprintf(dev_path, sizeof(dev_path),
+			 "/dev/vfio/devices/%s", entry->d_name);
+		fd = open(dev_path, O_RDWR);
+		if (fd < 0)
+			ublk_err( "open %s: %s\n", dev_path, strerror(errno));
+		break;
+	}
+
+	closedir(dir);
+
+	if (fd < 0)
+		ublk_err( "No VFIO cdev found for %s\n", pci_addr);
+
+	return fd;
+}
+
+/*
+ * Setup iommufd-based VFIO device access.
+ * Opens /dev/iommu, the VFIO cdev, binds the device to iommufd,
+ * allocates an IOAS, and attaches the device to it.
+ */
+int vfio_iommufd_setup(const char *pci_addr, int *iommufd, int *device_fd,
+		       __u32 *ioas_id, __u32 *dev_id)
+{
+	struct vfio_device_bind_iommufd bind = {};
+	struct iommu_ioas_alloc ioas_alloc = {};
+	struct vfio_device_attach_iommufd_pt attach = {};
+
+	/* Open /dev/iommu */
+	*iommufd = open("/dev/iommu", O_RDWR);
+	if (*iommufd < 0) {
+		ublk_err( "open /dev/iommu: %s\n", strerror(errno));
+		return -1;
+	}
+
+	/* Open VFIO cdev */
+	*device_fd = vfio_open_cdev(pci_addr);
+	if (*device_fd < 0)
+		goto err_close_iommufd;
+
+	/* Bind device to iommufd */
+	bind.argsz = sizeof(bind);
+	bind.flags = 0;
+	bind.iommufd = *iommufd;
+	if (ioctl(*device_fd, VFIO_DEVICE_BIND_IOMMUFD, &bind) < 0) {
+		ublk_err( "VFIO_DEVICE_BIND_IOMMUFD: %s\n", strerror(errno));
+		goto err_close_device;
+	}
+	*dev_id = bind.out_devid;
+
+	/* Allocate IOAS */
+	ioas_alloc.size = sizeof(ioas_alloc);
+	ioas_alloc.flags = 0;
+	if (ioctl(*iommufd, IOMMU_IOAS_ALLOC, &ioas_alloc) < 0) {
+		ublk_err( "IOMMU_IOAS_ALLOC: %s\n", strerror(errno));
+		goto err_close_device;
+	}
+	*ioas_id = ioas_alloc.out_ioas_id;
+
+	/* Attach device to IOAS */
+	attach.argsz = sizeof(attach);
+	attach.flags = 0;
+	attach.pt_id = *ioas_id;
+	if (ioctl(*device_fd, VFIO_DEVICE_ATTACH_IOMMUFD_PT, &attach) < 0) {
+		ublk_err( "VFIO_DEVICE_ATTACH_IOMMUFD_PT: %s\n", strerror(errno));
+		goto err_destroy_ioas;
+	}
+
+	return 0;
+
+err_destroy_ioas:
+	{
+		struct iommu_destroy destroy = {};
+		destroy.size = sizeof(destroy);
+		destroy.id = *ioas_id;
+		ioctl(*iommufd, IOMMU_DESTROY, &destroy);
+	}
+err_close_device:
+	close(*device_fd);
+	*device_fd = -1;
+err_close_iommufd:
+	close(*iommufd);
+	*iommufd = -1;
+	return -1;
+}
+
+void vfio_iommufd_cleanup(int iommufd, int device_fd, __u32 ioas_id)
+{
+	struct vfio_device_detach_iommufd_pt detach = {};
+	struct iommu_destroy destroy = {};
+
+	detach.argsz = sizeof(detach);
+	ioctl(device_fd, VFIO_DEVICE_DETACH_IOMMUFD_PT, &detach);
+
+	destroy.size = sizeof(destroy);
+	destroy.id = ioas_id;
+	ioctl(iommufd, IOMMU_DESTROY, &destroy);
+
+	if (device_fd >= 0)
+		close(device_fd);
+	close(iommufd);
+}
+
+int vfio_iommufd_map_dma(int iommufd, __u32 ioas_id,
+			 void *vaddr, __u64 iova, size_t size)
+{
+	struct iommu_ioas_map map = {};
+
+	map.size = sizeof(map);
+	map.flags = IOMMU_IOAS_MAP_FIXED_IOVA |
+		    IOMMU_IOAS_MAP_WRITEABLE |
+		    IOMMU_IOAS_MAP_READABLE;
+	map.ioas_id = ioas_id;
+	map.user_va = (__u64)vaddr;
+	map.length = (size + PAGE_SIZE - 1) & ~((__u64)PAGE_SIZE - 1);
+	map.iova = iova;
+
+	if (ioctl(iommufd, IOMMU_IOAS_MAP, &map) < 0) {
+		ublk_err( "IOMMU_IOAS_MAP: %s\n", strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+void vfio_iommufd_unmap_dma(int iommufd, __u32 ioas_id,
+			    __u64 iova, size_t size)
+{
+	struct iommu_ioas_unmap unmap = {};
+
+	unmap.size = sizeof(unmap);
+	unmap.ioas_id = ioas_id;
+	unmap.iova = iova;
+	unmap.length = size;
+	ioctl(iommufd, IOMMU_IOAS_UNMAP, &unmap);
+}

--- a/targets/nvme/vfio_iommufd.h
+++ b/targets/nvme/vfio_iommufd.h
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: MIT or GPL-2.0-only */
+#ifndef VFIO_IOMMUFD_H
+#define VFIO_IOMMUFD_H
+
+#include <config.h>
+#include <linux/types.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef HAVE_VFIO_IOMMUFD
+
+int vfio_iommufd_setup(const char *pci_addr, int *iommufd, int *device_fd,
+		       __u32 *ioas_id, __u32 *dev_id);
+void vfio_iommufd_cleanup(int iommufd, int device_fd, __u32 ioas_id);
+int vfio_iommufd_map_dma(int iommufd, __u32 ioas_id,
+			 void *vaddr, __u64 iova, size_t size);
+void vfio_iommufd_unmap_dma(int iommufd, __u32 ioas_id,
+			    __u64 iova, size_t size);
+
+#else /* !HAVE_VFIO_IOMMUFD */
+
+static inline int vfio_iommufd_setup(const char *pci_addr, int *iommufd,
+				     int *device_fd, __u32 *ioas_id,
+				     __u32 *dev_id)
+{
+	return -1;
+}
+
+static inline void vfio_iommufd_cleanup(int iommufd, int device_fd,
+					__u32 ioas_id)
+{
+}
+
+static inline int vfio_iommufd_map_dma(int iommufd, __u32 ioas_id,
+				       void *vaddr, __u64 iova, size_t size)
+{
+	return -1;
+}
+
+static inline void vfio_iommufd_unmap_dma(int iommufd, __u32 ioas_id,
+					  __u64 iova, size_t size)
+{
+}
+
+#endif /* HAVE_VFIO_IOMMUFD */
+
+static inline bool vfio_iommufd_enabled(void)
+{
+#ifdef HAVE_VFIO_IOMMUFD
+	return true;
+#else
+	return false;
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VFIO_IOMMUFD_H */


### PR DESCRIPTION

```
nvme_vfio: refactor iommufd code into separate vfio_iommufd.{c,h}
nvme_vfio: add legacy VFIO container mode with conditional iommufd support
```

@hreinecke reported HAVE_VFIO_IOMMUFD can only be true on new kernel(v6.6+). 

So add legacy VFIO container mode, which is the fallback mode in case
of !HAVE_VFIO_IOMMUFD.

Also refactor  iommufd code by adding vfio_iommufd.{c,h} for keeping
nvme target code clean.

