### PR TITLE
Doc container mount namespace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,26 @@ use unprivileged ublk in docker
 
 - example of ublk in docker: ``tests/debug/ublk_docker``
 
+mount namespace caveat (container/pod)
+--------------------------------------
+
+**The ublk daemon must not share a mount namespace with any process that
+uses the ublk block device** (mounts a filesystem on ``/dev/ublkbN``,
+opens it for I/O, etc.).
+
+Reason: the ublk daemon serves I/O for ``/dev/ublkbN``, so I/O on that
+device only makes forward progress while the daemon is alive. When the
+daemon shares a mount namespace with a client of its own device (e.g. a
+filesystem mounted on ``/dev/ublkbN``), the daemon's exit can trigger an
+unmount that flushes I/O to the device — but the daemon is exiting and
+can no longer serve that I/O, so it self-deadlocks.
+
+Run the daemon in its own mount namespace, e.g. by calling
+``unshare(CLONE_NEWNS)`` at startup or launching it under
+``unshare --mount``. See
+`vmtest/tests/ublk-mntns-min.sh <https://github.com/ming1/vmtest/blob/main/tests/ublk-mntns-min.sh>`_
+for a minimal reproducer of what goes wrong otherwise.
+
 test
 ====
 


### PR DESCRIPTION
    The ublk daemon must not share a mount namespace with any process that
    uses the ublk block device, otherwise the daemon can self-deadlock in
    do_exit() when it ends up as the last task holding the namespace and
    runs cleanup_mnt() on its own /dev/ublkbN.
