### PR TITLE
Update unprivileged mode udev rules documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,16 +144,21 @@ At default, controlling ublk device needs privileged user, since
 is called privileged mode.
 
 For unprivilege mode, /dev/ublk-control needs to be allowed for
-all users, so the following udev rule need to be added:
+all users, so the following udev rule need to be added: ::
 
-KERNEL=="ublk-control", MODE="0666", OPTIONS+="static_node=ublk-control"
+    KERNEL=="ublk-control", MODE="0666", OPTIONS+="static_node=ublk-control"
+
+It is also possible to restrict access to members of a particular group, for
+example: ::
+
+    KERNEL=="ublk-control", GROUP="wheel", MODE="0660", OPTIONS+="static_node=ublk-control"
 
 Also when new ublk device is added, we need ublk to change device
 ownership to the device's real owner, so the following rules are
 needed: ::
 
-    KERNEL=="ublkc*",RUN+="ublk_chown.sh %k"
-    KERNEL=="ublkb*",RUN+="ublk_chown.sh %k"
+    KERNEL=="ublkc*",RUN+="ublk_chown.sh $kernel $env{ACTION}"
+    KERNEL=="ublkb*",RUN+="ublk_chown.sh $kernel $env{ACTION}"
 
 ``ublk_chown.sh`` can be found under ``utils/`` too.
 
@@ -163,7 +168,7 @@ With the above two administrator changes, unprivileged user can
 create/delete/list/use ublk device, also anyone which isn't permitted
 can't access and control this ublk devices(ublkc*/ublkb*)
 
-Unprivileged user can pass '--unprevileged' to 'ublk add' for creating
+Unprivileged user can pass '--unprivileged' to 'ublk add' for creating
 unprivileged ublk device, then the created ublk device is only available
 for the owner and administrator.
 


### PR DESCRIPTION
* ublk_chown.sh now takes the udev action (add/change/etc.) as an additional argument.  Add this the the udev rules for the ublkc and ublkd devices.

* Also switch to "long form" substitutions in the commands, to make it a bit cleared what they're doing.

* Fix formatting of the ublk-control udev rule.

* Fix typo (--unprevileged → --unprivileged).