### PR TITLE
build: Use pkgconf to detect libiscsi

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,9 +42,9 @@ ublk_null_CPPFLAGS = $(ublk_null_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
 ublk_null_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS)
 
 ublk_iscsi_SOURCES = $(TGT_DIR)/ublk.iscsi.cpp $(TGT_DIR)/ublksrv_tgt.cpp
-ublk_iscsi_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
+ublk_iscsi_CFLAGS = $(WARNINGS_CFLAGS) $(LIBISCSI_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)
 ublk_iscsi_CPPFLAGS = $(ublk_iscsi_CFLAGS) -I$(top_srcdir)/include -I$(TGT_INC)
-ublk_iscsi_LDADD = lib/libublksrv.la $(LIBURING_LIBS) $(PTHREAD_LIBS) -liscsi
+ublk_iscsi_LDADD = lib/libublksrv.la $(LIBISCSI_LIBS) $(LIBURING_LIBS) $(PTHREAD_LIBS) -liscsi
 
 ublk_loop_SOURCES = $(TGT_DIR)/ublk.loop.cpp $(TGT_DIR)/ublksrv_tgt.cpp
 ublk_loop_CFLAGS = $(WARNINGS_CFLAGS) $(LIBURING_CFLAGS) $(PTHREAD_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -135,20 +135,15 @@ AC_ARG_WITH([libiscsi],
 )
 if test "x$with_libiscsi" != "xno"; then
     	AC_MSG_CHECKING([for libiscsi])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <iscsi/iscsi.h>
-	]], [[
-		int i = LIBISCSI_IMMEDIATE_SOCKET_WRITE;
-	]])],
+        PKG_CHECK_MODULES([libiscsi], [libiscsi],
 	[AC_MSG_RESULT([yes])
-	 AM_CONDITIONAL([HAVE_LIBISCSI], true)
+         AC_SUBST([LIBISCSI_CFLAGS])
+         AC_SUBST([LIBISCSI_LIBS])
 	 AC_DEFINE([HAVE_LIBISCSI], [1], [Define to 1 if libiscsi is available])],
-	[AC_MSG_RESULT([no])
-	 AM_CONDITIONAL([HAVE_LIBISCSI], false)])
-else
-	 AM_CONDITIONAL([HAVE_LIBISCSI], false)
+	[AC_MSG_RESULT([no])]
+        )
 fi
-AM_CONDITIONAL([LIBISCSI], [test "x$HAVE_LIBISCSI" = "x1"])
+AM_CONDITIONAL([HAVE_LIBISCSI], [test "x$LIBISCSI_LIBS" != "x"])
 
 #gnutls is only for nbd target, borrowed from nbd-client project
 AC_ARG_WITH([gnutls],


### PR DESCRIPTION
The way that libiscsi was being detected was broken.  On Fedora:

  $ pkgconf libiscsi --libs
  -L/usr/lib64/iscsi -liscsi

Use pkgconf to detect libiscsi, and set the right CFLAGS and LIBS if available.

Also remove unused AM_CONDITIONAL(LIBISCSI)