### PR TITLE
Nbd zc

### DIFF
--- a/include/ublksrv.h
+++ b/include/ublksrv.h
@@ -46,6 +46,19 @@ extern "C" {
  */
 #define UBLKSRV_F_NEED_POLL		(1UL << 2)
 
+/*
+ * Target drives UBLK_F_AUTO_BUF_REG zero copy through io_uring net
+ * send/recv, i.e. it sets IORING_RECVSEND_FIXED_BUF on a plain send/recv
+ * to reference the request's kernel-registered buffer (e.g. nbd).
+ *
+ * That flag is only honored on a plain send/recv from the 7.2 kernel on;
+ * UBLK_F_AUTO_BUF_REG (a ublk-driver feature) can be present on an older
+ * kernel whose io_uring/net half lacks it. When set, ublksrv probes the
+ * running kernel before enabling AUTO_BUF_REG and silently falls back to
+ * the copy path if the support is missing.
+ */
+#define UBLKSRV_F_ZC_NEEDS_NET_FIXED_BUF	(1UL << 3)
+
 struct io_uring;
 struct io_uring_cqe;
 struct ublksrv_aio_ctx;

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -29,10 +29,17 @@
 #define NBD_MAX_NAME	512
 
 #define NBD_OP_READ_REPLY  0x81
+/*
+ * Marks the data half of an auto_zc WRITE, which is split into a header
+ * send + a registered-buffer data send. The send-completion path uses it
+ * to compute the per-sqe expected length (data only, not header+data).
+ */
+#define NBD_OP_WRITE_DATA  0x82
 
 struct nbd_tgt_data {
 	bool unix_sock;
 	bool use_send_zc;
+	bool auto_zc;
 };
 
 #ifndef HAVE_LIBURING_SEND_ZC
@@ -217,14 +224,9 @@ static int nbd_queue_req(const struct ublksrv_queue *q,
 	const struct ublksrv_io_desc *iod = data->iod;
 	unsigned ublk_op = ublksrv_get_op(iod);
 	unsigned msg_flags = MSG_NOSIGNAL;
-	struct io_uring_sqe *sqe[1];
-
-	ublk_queue_alloc_sqes(q, sqe, 1);
-	if (!sqe[0]) {
-		nbd_err("%s: get sqe failed, tag %d op %d\n",
-				__func__, data->tag, ublk_op);
-		return -ENOMEM;
-	}
+	bool zc_write = ublksrv_tgt_queue_auto_zc(q) &&
+		ublk_op == UBLK_IO_OP_WRITE;
+	struct io_uring_sqe *sqe[2];
 
 	/*
 	 * Always set WAITALL, so io_uring will handle retry in case of
@@ -235,6 +237,20 @@ static int nbd_queue_req(const struct ublksrv_queue *q,
 	 * note: It was added for recv* in 5.18 and send* in 5.19.
 	 */
 	msg_flags |= MSG_WAITALL;
+
+	/*
+	 * A zc WRITE is two linked sends: the header sendmsg below (one iov,
+	 * see __nbd_handle_io_async) plus the data send appended afterwards.
+	 * Both sqes must come from one allocation: ublk_queue_alloc_sqes() may
+	 * submit when the SQ is low, and a mid-chain submit would cut the link
+	 * chain and reorder writes on the single TCP stream.
+	 */
+	ublk_queue_alloc_sqes(q, sqe, zc_write ? 2 : 1);
+	if (!sqe[0] || (zc_write && !sqe[1])) {
+		nbd_err("%s: get sqe failed, tag %d op %d\n",
+				__func__, data->tag, ublk_op);
+		return -ENOMEM;
+	}
 
 	if (q_data->use_send_zc)
 		io_uring_prep_sendmsg_zc(sqe[0], q->q_id + 1, msg, msg_flags);
@@ -251,6 +267,24 @@ static int nbd_queue_req(const struct ublksrv_queue *q,
 	io_uring_sqe_set_flags(sqe[0], /*IOSQE_CQE_SKIP_SUCCESS |*/
 			IOSQE_FIXED_FILE | IOSQE_IO_LINK);
 	nbd_chain_append_send(q_data, sqe[0]);
+
+	/*
+	 * auto_zc can't bounce data through iod->addr (not mapped), so send the
+	 * write data straight from the request's kernel-registered buffer
+	 * (index == tag) via a linked IORING_RECVSEND_FIXED_BUF send. The
+	 * NBD_OP_WRITE_DATA tag makes the send-completion short-send check use
+	 * the data-only expected length.
+	 */
+	if (zc_write) {
+		io_uring_prep_send(sqe[1], q->q_id + 1, NULL,
+				iod->nr_sectors << 9, msg_flags);
+		sqe[1]->ioprio |= IORING_RECVSEND_FIXED_BUF;
+		sqe[1]->buf_index = data->tag;
+		sqe[1]->user_data = build_user_data(data->tag, NBD_OP_WRITE_DATA,
+				iod->nr_sectors, 1);
+		io_uring_sqe_set_flags(sqe[1], IOSQE_FIXED_FILE | IOSQE_IO_LINK);
+		nbd_chain_append_send(q_data, sqe[1]);
+	}
 
 	NBD_IO_DBG("%s: queue io op %d(%llu %x %llx) ios(%u %u)"
 			" (qid %d tag %u, cmd_op %u target: %d, user_data %llx)\n",
@@ -283,7 +317,13 @@ static co_io_job __nbd_handle_io_async(const struct ublksrv_queue *q,
 	};
 	struct msghdr msg = {
 		.msg_iov = iov,
-		.msg_iovlen = (op == UBLK_IO_OP_WRITE) ? 2UL : 1UL,
+		/*
+		 * Under auto_zc the write data is sent separately from the
+		 * request's registered buffer, so the header sendmsg carries
+		 * the 28-byte header only.
+		 */
+		.msg_iovlen = (op == UBLK_IO_OP_WRITE &&
+				!ublksrv_tgt_queue_auto_zc(q)) ? 2UL : 1UL,
 	};
 
 	if (type == -1)
@@ -419,10 +459,18 @@ static void __nbd_resume_read_req(const struct ublk_io_data *data,
 	io->co.resume();
 }
 
-/* recv completion drives the whole IO flow */
+/*
+ * recv completion drives the whole IO flow
+ *
+ * Under auto_zc the READ data is recv'd straight into the request's
+ * kernel-registered buffer via IORING_RECVSEND_FIXED_BUF. That buffer has
+ * no userspace address, so for the (non-reply) data recv @buf is unused and
+ * @tag selects the registered buffer (index == tag), with the resume offset
+ * @done passed as the in-buffer offset (sqe->addr).
+ */
 static inline int nbd_start_recv(const struct ublksrv_queue *q,
 		struct nbd_io_data *nbd_data, void *buf, int len,
-		bool reply, unsigned done)
+		bool reply, unsigned done, int zc_buf_idx)
 {
 	struct nbd_queue_data *q_data = nbd_get_queue_data(q);
 	unsigned int op = reply ? NBD_OP_READ_REPLY : UBLK_IO_OP_READ;
@@ -437,7 +485,15 @@ static inline int nbd_start_recv(const struct ublksrv_queue *q,
 	}
 
 	nbd_data->done = done;
-	io_uring_prep_recv(sqe[0], q->q_id + 1, (char *)buf + done, len - done, MSG_WAITALL);
+	if (zc_buf_idx >= 0) {
+		io_uring_prep_recv(sqe[0], q->q_id + 1,
+				(void *)(uintptr_t)done, len - done, MSG_WAITALL);
+		sqe[0]->ioprio |= IORING_RECVSEND_FIXED_BUF;
+		sqe[0]->buf_index = zc_buf_idx;
+	} else {
+		io_uring_prep_recv(sqe[0], q->q_id + 1, (char *)buf + done,
+				len - done, MSG_WAITALL);
+	}
 	io_uring_sqe_set_flags(sqe[0], IOSQE_FIXED_FILE);
 
 	/* bit63 marks us as tgt io */
@@ -462,13 +518,21 @@ static inline int nbd_start_recv(const struct ublksrv_queue *q,
  */
 static int nbd_do_recv(const struct ublksrv_queue *q,
 		struct nbd_io_data *nbd_data, int fd,
-		void *buf, unsigned len)
+		void *buf, unsigned len, int zc_buf_idx)
 {
 	unsigned msg_flags = MSG_DONTWAIT | MSG_WAITALL;
 	int i = 0;
 	unsigned done = 0;
 	const int loops = len < 512 ? 16 : 32;
 	int ret;
+
+	/*
+	 * Under auto_zc the READ data lands in the request's kernel-registered
+	 * buffer (index == @zc_buf_idx), which has no userspace address, so the
+	 * sync recv() fast path can't be used. Recv straight into that buffer.
+	 */
+	if (zc_buf_idx >= 0)
+		return nbd_start_recv(q, nbd_data, buf, len, false, 0, zc_buf_idx);
 
 	while (i++ < loops && done < len) {
 		ret = recv(fd, (char *)buf + done, len - done, msg_flags);
@@ -483,7 +547,7 @@ static int nbd_do_recv(const struct ublksrv_queue *q,
 
 	NBD_IO_DBG("%s: sync(non-blocking) recv %d(%s)/%d/%u\n",
 			__func__, ret, strerror(errno), done, len);
-	ret = nbd_start_recv(q, nbd_data, buf, len, len < 512, done);
+	ret = nbd_start_recv(q, nbd_data, buf, len, len < 512, done, zc_buf_idx);
 
 	return ret;
 }
@@ -508,6 +572,7 @@ static co_io_job __nbd_handle_recv(const struct ublksrv_queue *q,
 	 */
 	u64 cqe_buf[2] = {0};
 	struct io_uring_cqe *fake_cqe = (struct io_uring_cqe *)cqe_buf;
+	bool use_zc = ublksrv_tgt_queue_auto_zc(q);
 
 	q_data->recv_started = 1;
 
@@ -525,7 +590,7 @@ static co_io_job __nbd_handle_recv(const struct ublksrv_queue *q,
 		 */
 		do {
 			ret = nbd_do_recv(q, nbd_data, fd, &q_data->reply,
-					sizeof(q_data->reply));
+					sizeof(q_data->reply), -1);
 			if (ret == sizeof(q_data->reply)) {
 				nbd_data->done = ret;
 				fake_cqe->res = 0;
@@ -547,9 +612,15 @@ static co_io_job __nbd_handle_recv(const struct ublksrv_queue *q,
 		ublk_assert(io_data != NULL);
 		unsigned int len = io_data->iod->nr_sectors << 9;
 
+		/*
+		 * Under auto_zc, pass io_data->tag so nbd_do_recv() recvs into
+		 * the request's registered buffer; otherwise pass -1 and recv
+		 * into @addr on the non-zc path.
+		 */
 		do {
 			ret = nbd_do_recv(q, nbd_data, fd,
-					(void *)io_data->iod->addr, len);
+					(void *)io_data->iod->addr, len,
+					use_zc ? (int)io_data->tag : -1);
 			if (ret == (int)len) {
 				nbd_data->done = ret;
 				fake_cqe->res = 0;
@@ -618,9 +689,15 @@ static void nbd_send_req_done(const struct ublksrv_queue *q,
 
 	/*
 	 * We have set MSG_WAITALL, so short send shouldn't be possible,
-	 * but just warn in case of io_uring regression
+	 * but just warn in case of io_uring regression.
+	 *
+	 * Under auto_zc a WRITE is two sends: a header (op == UBLK_IO_OP_WRITE,
+	 * 28 bytes) and a registered-buffer data send (op == NBD_OP_WRITE_DATA,
+	 * data bytes only). Non-auto_zc WRITE is a single header+data sendmsg.
 	 */
-	if (ublk_op == UBLK_IO_OP_WRITE)
+	if (ublk_op == NBD_OP_WRITE_DATA)
+		total = nr_sects << 9;
+	else if (ublk_op == UBLK_IO_OP_WRITE && !ublksrv_tgt_queue_auto_zc(q))
 		total = sizeof(nbd_request) + (nr_sects << 9);
 	else
 		total = sizeof(nbd_request);
@@ -936,8 +1013,20 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type,
 	 * the preferred queue depth should be 127 or 255,
 	 * then half of SQ memory consumption can be saved
 	 * especially we use IORING_SETUP_SQE128
+	 *
+	 * Under auto_zc a WRITE is split into two linked send sqes (header +
+	 * registered-buffer data), so a full in-order send chain needs up to
+	 * 2 * queue_depth sqes. The whole chain must be queued and submitted
+	 * within a single io_uring_enter(): io_uring link chains cannot span
+	 * submissions, so if ublk_queue_alloc_sqes() runs out of SQ space and
+	 * forces a mid-chain io_uring_submit(), the chain is cut and the
+	 * remaining sends race the earlier ones, reordering writes on the
+	 * single TCP stream. Size the ring so that never happens.
 	 */
-	tgt->tgt_ring_depth = info->queue_depth + 1;
+	if (info->flags & UBLK_F_AUTO_BUF_REG)
+		tgt->tgt_ring_depth = 2 * (info->queue_depth + 1);
+	else
+		tgt->tgt_ring_depth = info->queue_depth + 1;
 	tgt->nr_fds = info->nr_hw_queues;
 	tgt->extra_ios = 1;	//one extra slot for receiving nbd reply
 	data->unix_sock = strlen(unix_path) > 0;
@@ -948,7 +1037,26 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type,
 
 	ublksrv_dev_set_cq_depth(dev, 2 * tgt->tgt_ring_depth);
 
-	if (info->flags & (UBLK_F_SUPPORT_ZERO_COPY | UBLK_F_AUTO_BUF_REG))
+	/*
+	 * Zero copy is only supported via UBLK_F_AUTO_BUF_REG: the kernel
+	 * auto-registers each request's buffer at index == tag, and the send/
+	 * recv data sqes reference it with IORING_RECVSEND_FIXED_BUF. The
+	 * explicit register/unregister UBLK_F_SUPPORT_ZERO_COPY (without the
+	 * auto upgrade, i.e. an old kernel) and UBLK_F_USER_COPY are rejected.
+	 */
+	if (info->flags & UBLK_F_AUTO_BUF_REG) {
+		/*
+		 * An auto_zc WRITE is sent as two sqes (header + registered-
+		 * buffer data). Combining that with sendmsg_zc's NOTIF
+		 * completions isn't supported, so reject the combination.
+		 */
+		if (data->use_send_zc) {
+			nbd_err("%s: send_zc not supported with auto buf register\n",
+					__func__);
+			return -EINVAL;
+		}
+		data->auto_zc = true;
+	} else if (info->flags & UBLK_F_SUPPORT_ZERO_COPY)
 		return -EINVAL;
 	return 0;
 }

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -45,6 +45,16 @@ struct nbd_tgt_data {
 #ifndef HAVE_LIBURING_SEND_ZC
 #define io_uring_prep_sendmsg_zc io_uring_prep_sendmsg
 #define IORING_CQE_F_NOTIF (1U << 3)
+/*
+ * Fallback so the send_zc data path still compiles; it is never reached
+ * because the send_zc option is rejected at init time without liburing
+ * send_zc support.
+ */
+static inline void io_uring_prep_send_zc(struct io_uring_sqe *sqe, int sockfd,
+		const void *buf, size_t len, int flags, unsigned zc_flags)
+{
+	io_uring_prep_send(sqe, sockfd, buf, len, flags);
+}
 #endif
 
 struct nbd_queue_data {
@@ -252,7 +262,13 @@ static int nbd_queue_req(const struct ublksrv_queue *q,
 		return -ENOMEM;
 	}
 
-	if (q_data->use_send_zc)
+	/*
+	 * Under auto_zc the header is a 28-byte sendmsg of its own; keep it a
+	 * plain sendmsg and reserve zero-copy for the registered-buffer data
+	 * send below. Only the combined header+data sendmsg of the non-auto_zc
+	 * path benefits from sendmsg_zc.
+	 */
+	if (q_data->use_send_zc && !ublksrv_tgt_queue_auto_zc(q))
 		io_uring_prep_sendmsg_zc(sqe[0], q->q_id + 1, msg, msg_flags);
 	else
 		io_uring_prep_sendmsg(sqe[0], q->q_id + 1, msg, msg_flags);
@@ -276,8 +292,18 @@ static int nbd_queue_req(const struct ublksrv_queue *q,
 	 * the data-only expected length.
 	 */
 	if (zc_write) {
-		io_uring_prep_send(sqe[1], q->q_id + 1, NULL,
-				iod->nr_sectors << 9, msg_flags);
+		/*
+		 * With send_zc the data is sent straight from the registered
+		 * buffer without a copy; it yields an extra IORING_CQE_F_NOTIF
+		 * completion (ignored in nbd_send_req_done). Otherwise a plain
+		 * fixed-buffer send copies the data into the skb.
+		 */
+		if (q_data->use_send_zc)
+			io_uring_prep_send_zc(sqe[1], q->q_id + 1, NULL,
+					iod->nr_sectors << 9, msg_flags, 0);
+		else
+			io_uring_prep_send(sqe[1], q->q_id + 1, NULL,
+					iod->nr_sectors << 9, msg_flags);
 		sqe[1]->ioprio |= IORING_RECVSEND_FIXED_BUF;
 		sqe[1]->buf_index = data->tag;
 		sqe[1]->user_data = build_user_data(data->tag, NBD_OP_WRITE_DATA,
@@ -1046,15 +1072,11 @@ static int nbd_setup_tgt(struct ublksrv_dev *dev, int type,
 	 */
 	if (info->flags & UBLK_F_AUTO_BUF_REG) {
 		/*
-		 * An auto_zc WRITE is sent as two sqes (header + registered-
-		 * buffer data). Combining that with sendmsg_zc's NOTIF
-		 * completions isn't supported, so reject the combination.
+		 * An auto_zc WRITE is sent as two sqes (a plain header sendmsg
+		 * plus the registered-buffer data send). With send_zc the data
+		 * send becomes IORING_OP_SEND_ZC, whose extra NOTIF completion
+		 * is handled in nbd_send_req_done().
 		 */
-		if (data->use_send_zc) {
-			nbd_err("%s: send_zc not supported with auto buf register\n",
-					__func__);
-			return -EINVAL;
-		}
 		data->auto_zc = true;
 	} else if (info->flags & UBLK_F_SUPPORT_ZERO_COPY)
 		return -EINVAL;

--- a/targets/nbd/ublk.nbd.cpp
+++ b/targets/nbd/ublk.nbd.cpp
@@ -1220,6 +1220,13 @@ static const struct ublksrv_tgt_type  nbd_tgt_type = {
 	.usage_for_add = nbd_cmd_usage,
 	.init_tgt = nbd_init_tgt,
 	.deinit_tgt = nbd_deinit_tgt,
+	/*
+	 * nbd zero copy (UBLK_F_AUTO_BUF_REG) sends/recvs request data
+	 * straight from/into the registered buffer with a plain send/recv
+	 * carrying IORING_RECVSEND_FIXED_BUF, which needs a >= 7.2 kernel.
+	 * Make ublksrv probe for it and fall back to the copy path otherwise.
+	 */
+	.ublksrv_flags = UBLKSRV_F_ZC_NEEDS_NET_FIXED_BUF,
 	.name	=  "nbd",
 	.init_queue = nbd_init_queue,
 	.deinit_queue = nbd_deinit_queue,

--- a/targets/ublksrv_tgt.cpp
+++ b/targets/ublksrv_tgt.cpp
@@ -774,6 +774,78 @@ static void ublksrv_print_std_opts(void)
 	printf("\t--debug_mask=0x{DBG_MASK} --unprivileged\n");
 }
 
+/*
+ * Probe whether the running kernel honors IORING_RECVSEND_FIXED_BUF on a
+ * plain io_uring recv (the always-needed half of net AUTO_BUF_REG zero
+ * copy; plain-send fixed-buf support lands in the same 7.2 series). A
+ * pre-7.2 kernel rejects the flag at issue time with -EINVAL/-EOPNOTSUPP,
+ * so submit a real recv against a preloaded socketpair and a registered
+ * buffer, and treat a non-positive cqe result as "unsupported".
+ *
+ * Returns true iff supported. Any setup failure is reported as unsupported
+ * so the caller conservatively falls back to the copy path.
+ */
+static bool ublksrv_probe_net_fixed_buf(void)
+{
+	struct io_uring ring;
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	struct iovec iov;
+	char rbuf[8] = {0};
+	const char sbuf[8] = "zcprobe";
+	int sv[2], res;
+	bool supported = false;
+
+	if (io_uring_queue_init(2, &ring, 0) < 0)
+		return false;
+
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) < 0)
+		goto exit_ring;
+
+	iov.iov_base = rbuf;
+	iov.iov_len = sizeof(rbuf);
+	if (io_uring_register_buffers(&ring, &iov, 1) < 0)
+		goto close_sock;
+
+	/* preload data so a supported recv completes instead of blocking */
+	if (write(sv[1], sbuf, sizeof(sbuf)) != (ssize_t)sizeof(sbuf))
+		goto unreg;
+
+	sqe = io_uring_get_sqe(&ring);
+	/*
+	 * For a fixed-buffer send/recv against a userspace-registered buffer,
+	 * sqe->addr is an absolute address inside the registered buffer (the
+	 * kernel derives the in-buffer offset as addr - buf_base), exactly
+	 * like IORING_OP_READ_FIXED. So pass the buffer's own base (offset 0),
+	 * not NULL - NULL is outside the buffer and faults with -EFAULT even on
+	 * a supporting kernel. An unsupported kernel rejects the flag earlier
+	 * with -EINVAL regardless of the address.
+	 */
+	io_uring_prep_recv(sqe, sv[0], rbuf, sizeof(rbuf), MSG_DONTWAIT);
+	sqe->ioprio |= IORING_RECVSEND_FIXED_BUF;
+	sqe->buf_index = 0;
+
+	if (io_uring_submit(&ring) < 0)
+		goto unreg;
+	if (io_uring_wait_cqe(&ring, &cqe) < 0)
+		goto unreg;
+
+	res = cqe->res;
+	io_uring_cqe_seen(&ring, cqe);
+	/* supported: bytes copied into the registered buffer (res > 0) */
+	supported = res > 0;
+
+ unreg:
+	io_uring_unregister_buffers(&ring);
+ close_sock:
+	close(sv[0]);
+	close(sv[1]);
+ exit_ring:
+	io_uring_queue_exit(&ring);
+
+	return supported;
+}
+
 static int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc, char *argv[])
 {
 	struct ublksrv_dev_data data = {0};
@@ -842,6 +914,32 @@ static int ublksrv_cmd_dev_add(const struct ublksrv_tgt_type *tgt_type, int argc
 			ublksrv_ctrl_deinit(dev);
 			dev = ublksrv_ctrl_init(&data);
 		}
+
+		/*
+		 * A net target (e.g. nbd) references the request's registered
+		 * buffer from a plain send/recv via IORING_RECVSEND_FIXED_BUF.
+		 * That only works from the 7.2 kernel on, independently of the
+		 * ublk-side UBLK_F_AUTO_BUF_REG feature checked above. If the
+		 * running kernel lacks it, fall back to the copy path by
+		 * dropping both zero-copy flags before the device is created.
+		 */
+		if ((data.flags & UBLK_F_AUTO_BUF_REG) &&
+		    (data.ublksrv_flags & UBLKSRV_F_ZC_NEEDS_NET_FIXED_BUF) &&
+		    !ublksrv_probe_net_fixed_buf()) {
+			fprintf(stderr, "ublk: kernel lacks io_uring net "
+				"registered-buffer send/recv; "
+				"falling back to copy (no zero copy)\n");
+			data.flags &= ~(UBLK_F_AUTO_BUF_REG |
+					UBLK_F_SUPPORT_ZERO_COPY);
+			ublksrv_ctrl_deinit(dev);
+			dev = ublksrv_ctrl_init(&data);
+		}
+	}
+
+	if (!dev) {
+		fprintf(stderr, "can't re-init dev %d\n", data.dev_id);
+		ret = -EOPNOTSUPP;
+		goto fail_send_event;
 	}
 
 	ret = ublksrv_ctrl_add_dev(dev);

--- a/tests/nbd/045
+++ b/tests/nbd/045
@@ -1,0 +1,53 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0
+
+. common/fio_common
+. common/nbd_common
+
+echo "run zero copy(auto buf reg) test via ublk-nbd(nbd server: $NBDSRV:nbdkit memory $NBD_SIZE)"
+
+file=`_create_image "nbd" "none" $NBD_SIZE`
+
+# -z negotiates UBLK_F_SUPPORT_ZERO_COPY, which the lib upgrades to
+# UBLK_F_AUTO_BUF_REG when the kernel supports it.
+export T_TYPE_PARAMS="-t nbd -q 1 -d 127 --host $NBDSRV -z"
+DEV=`__create_ublk_dev`
+
+if [ "$DEV" == "/dev/ublkb-unknown" ]; then
+	echo "FAIL: ublk-nbd zero copy device not created"
+	_remove_image "nbd" $file
+	exit 1
+fi
+
+# Confirm zero copy is actually active rather than silently falling back.
+dev_id=`__ublk_dev_id $DEV`
+if eval $UBLK list -n $dev_id | grep -q "AUTO_ZC"; then
+	echo -e "\tzero copy active: AUTO_ZC"
+else
+	echo "FAIL: AUTO_ZC not negotiated on $DEV"
+	__remove_ublk_dev $DEV
+	_remove_image "nbd" $file
+	exit 1
+fi
+
+# Data integrity: write crc32c-tagged data through the registered-buffer
+# write (send) path, then read it back through the registered-buffer recv
+# path and verify. Proves zero copy carries correct data both directions.
+EXTRA_FIO_OPTS="--size=256M --verify=crc32c --do_verify=1 --verify_fatal=1"
+__run_fio_libaio $DEV 64k write 1 0
+verify_res=$?
+unset EXTRA_FIO_OPTS
+
+if [ $verify_res -ne 0 ]; then
+	echo "FAIL: data verify failed on zero copy $DEV (fio $verify_res)"
+	__remove_ublk_dev $DEV
+	_remove_image "nbd" $file
+	exit 1
+fi
+echo -e "\tdata verify(crc32c): PASS"
+
+echo -e "\tublk add ${T_TYPE_PARAMS}, fio: ($DEV libaio dio io jobs(1))..."
+__run_dev_perf_no_create "ublk" 1 $DEV
+
+__remove_ublk_dev $DEV
+_remove_image "nbd" $file

--- a/tests/nbd/046
+++ b/tests/nbd/046
@@ -1,0 +1,55 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0
+
+. common/fio_common
+. common/nbd_common
+
+echo "run send_zc zero copy(auto buf reg) test via ublk-nbd(nbd server: $NBDSRV:nbdkit memory $NBD_SIZE)"
+
+file=`_create_image "nbd" "none" $NBD_SIZE`
+
+# -z negotiates UBLK_F_SUPPORT_ZERO_COPY (upgraded to UBLK_F_AUTO_BUF_REG
+# when the kernel supports it); --send_zc additionally sends the WRITE data
+# straight from the registered buffer via IORING_OP_SEND_ZC (true zero copy)
+# instead of a copying fixed-buffer send.
+export T_TYPE_PARAMS="-t nbd -q 1 -d 127 --host $NBDSRV -z --send_zc"
+DEV=`__create_ublk_dev`
+
+if [ "$DEV" == "/dev/ublkb-unknown" ]; then
+	echo "FAIL: ublk-nbd send_zc zero copy device not created"
+	_remove_image "nbd" $file
+	exit 1
+fi
+
+# Confirm zero copy is actually active rather than silently falling back.
+dev_id=`__ublk_dev_id $DEV`
+if eval $UBLK list -n $dev_id | grep -q "AUTO_ZC"; then
+	echo -e "\tzero copy active: AUTO_ZC"
+else
+	echo "FAIL: AUTO_ZC not negotiated on $DEV"
+	__remove_ublk_dev $DEV
+	_remove_image "nbd" $file
+	exit 1
+fi
+
+# Data integrity: write crc32c-tagged data through the send_zc registered-
+# buffer write path, then read it back through the registered-buffer recv
+# path and verify. Proves the SEND_ZC data send carries correct data.
+EXTRA_FIO_OPTS="--size=256M --verify=crc32c --do_verify=1 --verify_fatal=1"
+__run_fio_libaio $DEV 64k write 1 0
+verify_res=$?
+unset EXTRA_FIO_OPTS
+
+if [ $verify_res -ne 0 ]; then
+	echo "FAIL: data verify failed on send_zc zero copy $DEV (fio $verify_res)"
+	__remove_ublk_dev $DEV
+	_remove_image "nbd" $file
+	exit 1
+fi
+echo -e "\tdata verify(crc32c): PASS"
+
+echo -e "\tublk add ${T_TYPE_PARAMS}, fio: ($DEV libaio dio io jobs(1))..."
+__run_dev_perf_no_create "ublk" 1 $DEV
+
+__remove_ublk_dev $DEV
+_remove_image "nbd" $file


### PR DESCRIPTION
support nbd zero copy, which requires linux kernel >= 7.2, especially:

57ed21fad402 io_uring/net: support registered buffer for plain send and recv