### PR TITLE
Fix PR_SET_IO_FLUSHER to set the flag instead of clearing it

### DIFF
--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -5,6 +5,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/prctl.h>
+#include <linux/prctl.h>
 
 #include "ublksrv_priv.h"
 #include "ublksrv_aio.h"

--- a/lib/ublksrv.c
+++ b/lib/ublksrv.c
@@ -4,6 +4,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/prctl.h>
 
 #include "ublksrv_priv.h"
 #include "ublksrv_aio.h"
@@ -854,7 +855,7 @@ skip_alloc_buf:
 	* N.B. PR_SET_IO_FLUSHER was added with Linux 5.6+.
 	*/
 #if defined(PR_SET_IO_FLUSHER)
-	if (prctl(PR_SET_IO_FLUSHER, 0, 0, 0, 0) != 0)
+	if (prctl(PR_SET_IO_FLUSHER, 1, 0, 0, 0) != 0)
 		ublk_err("ublk dev %d queue %d set_io_flusher failed",
 			q->dev->ctrl_dev->dev_info.dev_id, q->q_id);
 #endif

--- a/tests/generic/008
+++ b/tests/generic/008
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT or GPL-2.0-only
+
+. common/fio_common
+
+echo -e "\tcheck queue pthread is put into IO_FLUSHER state"
+
+QUEUES=2
+
+# PR_SET_IO_FLUSHER sets PF_MEMALLOC_NOIO(0x00080000) and
+# PF_LOCAL_THROTTLE(0x00100000) in the task flags
+IO_FLUSHER_FLAGS=$((0x00080000 | 0x00100000))
+
+__task_flags()
+{
+	local pid=$1
+	local tid=$2
+
+	# flags is the 7th field after the comm's closing paren
+	sed 's/.*) //' /proc/${pid}/task/${tid}/stat | awk '{print $7}'
+}
+
+export T_TYPE_PARAMS="-t null -q $QUEUES"
+DEV=`__create_ublk_dev`
+PID=`__ublk_get_pid $DEV`
+
+for Q in `seq 0 $((QUEUES - 1))`; do
+	TID=`__ublk_get_queue_tid $DEV $Q`
+	FLAGS=`__task_flags $PID $TID`
+	if [ $((FLAGS & IO_FLUSHER_FLAGS)) -ne $IO_FLUSHER_FLAGS ]; then
+		echo -e "\tqueue $Q tid $TID not in IO_FLUSHER state(flags $FLAGS)"
+	fi
+done
+
+__remove_ublk_dev $DEV


### PR DESCRIPTION
Existing code -
```
prctl(PR_SET_IO_FLUSHER, 0, 0, 0, 0)
```

This does not _set_ but _clears_ the `IO_FLUSHER` state.

It should be -

```
prctl(PR_SET_IO_FLUSHER, 1, 0, 0, 0)
```

Also need to re-add `#include <sys/prctl.h>` otherwise this gets silently ignored anyway.

----

From https://man7.org/linux/man-pages/man2/pr_set_io_flusher.2const.html -

> `int prctl(PR_SET_IO_FLUSHER, long state, 0L, 0L, 0L);`
>
> If a user process is involved in the block layer or filesystem I/O
> path, and can allocate memory while processing I/O requests it
> **must set state to 1**.  This will put the process in the IO_FLUSHER
> state, which allows it special treatment to make progress when
> allocating memory.  If state is 0, the process will clear the
> IO_FLUSHER state, and the default behavior will be used.

Related: https://github.com/ublk-org/libublk-rs/pull/55