### PR TITLE
build: refresh linker cache on install

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,10 @@ LT_INIT
 AC_CANONICAL_HOST
 
 AC_PROG_SED
+AC_PATH_PROG([LDCONFIG], [ldconfig], [:],
+             [$PATH$PATH_SEPARATOR/sbin$PATH_SEPARATOR/usr/sbin])
+AS_IF([test "x$LDCONFIG" = "x:"],
+      [AC_MSG_WARN([ldconfig not found - linker cache will not be refreshed on install])])
 
 dnl Check for basic C environment.
 AC_PROG_CC

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -21,4 +21,15 @@ libublksrv_la_LIBADD = \
 libublksrv_la_LDFLAGS = \
 	-version-info 0:0:0
 
+install-exec-hook:
+	$(AM_V_at)if test -z "$(DESTDIR)"; then \
+		$(LDCONFIG) "$(libdir)" || \
+			echo "warning: $(LDCONFIG) failed; run it as root to refresh the linker cache"; \
+	fi
+
+uninstall-hook:
+	$(AM_V_at)if test -z "$(DESTDIR)"; then \
+		$(LDCONFIG) "$(libdir)" || :; \
+	fi
+
 CLEANFILES = *~ *.d


### PR DESCRIPTION
Run ldconfig after installing or uninstalling libublksrv so installed binaries can resolve the shared library. Skip it for DESTDIR builds.

Fixes #197