### PR TITLE
build: fix 'make distcheck'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,17 @@ ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = \
 	COPYING.LGPL \
 	.gitignore \
-	LICENSE
+	LICENSE \
+	targets/include/dma_buf.h \
+	targets/include/ublksrv_tgt.h \
+	targets/include/ublksrv_tgt_endian.h \
+	targets/nbd/cliserv.h \
+	targets/nbd/nbd-debug.h \
+	targets/nbd/nbd.h \
+	targets/nvme/nvme.h \
+	targets/nvme/vfio_iommufd.h \
+	targets/sheepdog/sheep.h \
+	targets/sheepdog/sheepdog_proto.h
 
 SUBDIRS = doc include lib tests
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,7 +1,12 @@
 XSLTPROC = /usr/bin/xsltproc
 
 # Manpages
-man1_MANS = ublk.1
+#
+# ublk.1 is generated from ublk.1.xml, but is kept in the tree and shipped in
+# the tarball: automake does not distribute plain man_MANS, so without dist_
+# the manpage is missing from the release and 'make distcheck' fails with
+# "No rule to make target 'ublk.1'".
+dist_man1_MANS = ublk.1
 
 %.1 : %.1.xml
 	-test -z "$(XSLTPROC)" || $(XSLTPROC) -o $@ http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -3,3 +3,8 @@
 # Public headers.
 include_HEADERS = ublksrv.h ublk_cmd.h ublksrv_aio.h ublksrv_utils.h
 
+# Private headers: not installed, but needed to build from the tarball.
+EXTRA_DIST = \
+	nlohmann/json.hpp \
+	ublksrv_priv.h
+


### PR DESCRIPTION
`make distcheck` fails on master, because the release tarball is missing files the build needs. This fixes exactly that, and nothing else.

## The failures

The manpage goes first:

```
make[3]: *** No rule to make target 'ublk.1', needed by 'all-am'.  Stop.
```

automake does **not** distribute plain `man_MANS` — it assumes they are build artifacts — so `ublk.1` never reached the tarball. Silent in a git checkout, where the file is simply present.

Past that, the build has no headers to compile against:

```
lib/ublksrv_cmd.c:5:10: fatal error: ublksrv_priv.h: No such file or directory
```

No header is listed in any `_SOURCES` (`grep -E "_SOURCES" Makefile.am | grep -c "\.h\b"` → 0), so automake never learned they exist. Note the contrast that proves the mechanism: `include/ublksrv.h` was already shipping, because `include_HEADERS` names it — its neighbour `ublksrv_priv.h` was not.

## Changes

| file | fix |
|---|---|
| `doc/Makefile.am` | `man1_MANS` → `dist_man1_MANS` |
| `include/Makefile.am` | ship `ublksrv_priv.h`, `nlohmann/json.hpp` |
| `Makefile.am` | ship the ten `targets/**/*.h` |

3 files, +22/-2. This is the minimal set: I verified that `distcheck` passes with exactly these and no more.

## Verification

```
$ make distcheck          # before
make[3]: *** No rule to make target 'ublk.1', needed by 'all-am'.  Stop.
rc=2

$ make distcheck          # after
ublksrv-1.7-37-g23461b7 archives ready for distribution
rc=0
```

Installation behaviour is unchanged — `EXTRA_DIST` affects only the tarball, so the private headers do not land in `$(includedir)`; confirmed that `make install` still puts exactly the four public headers there, and that the manpage still installs to `share/man/man1/ublk.1` after the `dist_` prefix.

Everything else — the tests list, `VERSION`, `genver.sh`, docs and CI — is not needed for `distcheck` and is in #200.
