### PR TITLE
build: distribute every file tracked in git

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,23 @@ EXTRA_DIST = \
 	targets/nvme/nvme.h \
 	targets/nvme/vfio_iommufd.h \
 	targets/sheepdog/sheep.h \
-	targets/sheepdog/sheepdog_proto.h
+	targets/sheepdog/sheepdog_proto.h \
+	VERSION \
+	README.rst \
+	build_with_liburing_src \
+	targets/nbd/README.rst \
+	utils/dump_ublk.py \
+	utils/genver.sh \
+	utils/htlb.sh \
+	utils/ublk_dev.rules \
+	.github/workflows/build.yml \
+	.github/workflows/ci.yml \
+	ci/.gitignore \
+	ci/mkosi.build \
+	ci/mkosi.conf \
+	ci/mkosi.default.d/10-ubdsrv.conf \
+	ci/mkosi.default.d/fedora/10-fedora.conf \
+	ci/mkosi.extra/etc/modules-load.d/ublk-drv.conf
 
 SUBDIRS = doc include lib tests
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -8,5 +8,13 @@ XSLTPROC = /usr/bin/xsltproc
 # "No rule to make target 'ublk.1'".
 dist_man1_MANS = ublk.1
 
+EXTRA_DIST = \
+	ublk.1.xml \
+	Doxyfile \
+	mainpage.dox \
+	external_links.rst \
+	ublk_intro.pdf \
+	ublk_use_cases_and_progress_clsf2026.pdf
+
 %.1 : %.1.xml
 	-test -z "$(XSLTPROC)" || $(XSLTPROC) -o $@ http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,12 +9,22 @@ run:
 
 CLEANFILES = *~ */*~
 
+# Keep in sync with the test files tracked in git; 'make
+# maintainer-check-extra-dist' at the top level flags anything missing.
 EXTRA_DIST = \
 	common/fio_common \
 	common/loop_common \
+	common/nbd_common \
+	debug/test_dev \
+	debug/ublk_docker \
 	generic/001 \
 	generic/002 \
 	generic/003 \
+	generic/004 \
+	generic/005 \
+	generic/006 \
+	generic/007 \
+	generic/008 \
 	loop/001 \
 	loop/002 \
 	loop/003 \
@@ -22,9 +32,29 @@ EXTRA_DIST = \
 	loop/005 \
 	loop/006 \
 	loop/007 \
+	loop/008 \
+	loop/009 \
+	loop/010 \
+	loop/012 \
+	loop/013 \
+	nbd/001 \
+	nbd/002 \
+	nbd/003 \
+	nbd/021 \
+	nbd/022 \
+	nbd/023 \
+	nbd/024 \
+	nbd/041 \
+	nbd/042 \
+	nbd/043 \
+	nbd/044 \
+	nbd/045 \
+	nbd/046 \
 	null/001 \
 	null/002 \
 	null/004 \
 	null/005 \
 	null/006 \
+	null/007 \
+	null/012 \
 	run_test.sh


### PR DESCRIPTION
Follow-up to #199. That PR makes `make distcheck` pass; this one makes the tarball a faithful copy of the tree, so `make maintainer-check-extra-dist` passes too.

**Stacked on #199** (base is `doc-dist-manpage`). Merge #199 first and this rebases cleanly.

## Why

`make maintainer-check-extra-dist` diffs the tarball against `git ls-files` and has never passed. That is why files silently drifted out of the release and nobody noticed. With #199 alone the target still reports 42 files, so it remains red and enforces nothing.

automake cannot discover files by itself — there is no `.git` inside a tarball, and `distcheck` builds in a read-only extracted copy — so the list has to be declared.

## What is added

| group | detail |
|---|---|
| tests | the hand-maintained `EXTRA_DIST` had drifted: all of `nbd/`, `generic/004-008`, `loop/008-013`, `null/007`, `null/012` — 30 files — plus `utils/htlb.sh`, which `tests/loop/013` sources |
| version | `VERSION` and `utils/genver.sh`, so the version is still derivable after `autoreconf` in an unpacked tarball, where `git describe` has no repository to read |
| docs | `README.rst`, `targets/nbd/README.rst`, `doc/ublk.1.xml`, `doc/Doxyfile`, `doc/mainpage.dox`, `doc/external_links.rst`, both PDFs |
| dev utils | `build_with_liburing_src`, `utils/dump_ublk.py`, `utils/ublk_dev.rules` |
| CI | `.github/workflows/{build,ci}.yml`, `ci/mkosi.*` |

Shipping the CI configuration is deliberate — it keeps the tarball a faithful copy of the tree, so a release can be rebuilt and re-tested without cloning. If you would rather keep `ci/` and `.github/` out, the alternative is an exclusion filter in the check target; say the word and I will switch it.

## Cost

Tarball grows to 1.0M; 456K of the addition is the two PDFs under `doc/`.

## Verification

```
$ make maintainer-check-extra-dist
Checking for differences between EXTRA_DIST and git ...
PASS: EXTRA_DIST tests          # first time this has ever passed

$ make distcheck
ublksrv-1.7-37-g23461b7 archives ready for distribution
rc=0
```

51 test files now land in the tarball. From here the check target is self-enforcing: any new file added to git without a corresponding build-system entry fails it.
